### PR TITLE
Add new ShopEntryColors and ShopEntryRenderImage

### DIFF
--- a/docs/api/objects.rst
+++ b/docs/api/objects.rst
@@ -80,6 +80,9 @@ The API has many objects that represent different parts of the Fortnite API. Bel
 .. autoclass:: fortnite_api.Playlist
     :members:
 
+.. autoclass:: fortnite_api.ShopEntryOfferTag
+    :members:
+
 .. autoclass:: fortnite_api.ShopEntryBundle
     :members:
 

--- a/docs/api/objects.rst
+++ b/docs/api/objects.rst
@@ -89,6 +89,12 @@ The API has many objects that represent different parts of the Fortnite API. Bel
 .. autoclass:: fortnite_api.ShopEntryLayout
     :members:
 
+.. autoclass:: fortnite_api.ShopEntryColors
+    :members:
+
+.. autoclass:: fortnite_api.ShopEntryRenderImage
+    :members:
+
 .. autoclass:: fortnite_api.ShopEntryNewDisplayAsset
     :members:
 
@@ -227,6 +233,9 @@ Enumerations
     :members:
 
 .. autoclass:: fortnite_api.CustomGender
+    :members:
+
+.. autoclass:: fortnite_api.ProductTag
     :members:
 
 

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -424,8 +424,17 @@ class ProductTag(enum.Enum):
         The product is for all modes.
     """
 
-    BATTLE_ROYALE = 'Product.BR'
-    LEGO = 'Product.Juno'
-    ROCKET_RACING = 'Product.DelMar'
-    FESTIVAL = 'Product.Sparks'
-    ALL = 'Product.MAX'
+    BATTLE_ROYALE = 'br'
+    LEGO = 'juno'
+    ROCKET_RACING = 'delmar'
+    FESTIVAL = 'sparks'
+    ALL = 'max'
+
+    @classmethod
+    def _from_str(cls: Type[Self], string: str) -> Self:
+        # The Epic Games API uses both "CosmeticCompatibleMode" and "CosmeticCompatibleModeLegacy" enums
+        # with the same values, so we need to handle both.
+        # To easily handle this, we'll remove the "ECosmeticCompatibleMode::" or "ECosmeticCompatibleModeLegacy::" prefix.
+        # and then convert it to the enum.
+        trimmed = string.split('.')[-1]
+        return cls(trimmed.lower())

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -432,9 +432,7 @@ class ProductTag(enum.Enum):
 
     @classmethod
     def _from_str(cls: Type[Self], string: str) -> Self:
-        # The Epic Games API uses both "CosmeticCompatibleMode" and "CosmeticCompatibleModeLegacy" enums
-        # with the same values, so we need to handle both.
-        # To easily handle this, we'll remove the "ECosmeticCompatibleMode::" or "ECosmeticCompatibleModeLegacy::" prefix.
-        # and then convert it to the enum.
+        # The Epic Games API "Product" enums contains both lower case and capitalized values, so we need to handle both.
+        # To easily handle this, we'll remove the "Product." prefix and convert it to lowercase.
         trimmed = string.split('.')[-1]
         return cls(trimmed.lower())

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -405,3 +405,27 @@ class CustomGender(enum.Enum):
 
     FEMALE = 'EFortCustomGender::Female'
     MALE = 'EFortCustomGender::Male'
+
+
+class ProductTag(enum.Enum):
+    """A class that represents the tag of a product.
+
+    Attributes
+    ----------
+    BATTLE_ROYALE
+        The product is for Battle Royale.
+    LEGO
+        The product is for LEGO.
+    ROCKET_RACING
+        The product is for Rocket Racing.
+    FESTIVAL
+        The product is for Festival.
+    ALL
+        The product is for all modes.
+    """
+
+    BATTLE_ROYALE = 'Product.BR'
+    LEGO = 'Product.Juno'
+    ROCKET_RACING = 'Product.DelMar'
+    FESTIVAL = 'Product.Sparks'
+    ALL = 'Product.MAX'

--- a/fortnite_api/material.py
+++ b/fortnite_api/material.py
@@ -160,7 +160,7 @@ class MaterialInstance(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
 
         self.id: str = data["id"]
         self.primary_mode: CosmeticCompatibleMode = CosmeticCompatibleMode._from_str(data["primaryMode"])
-        self.product_tag: ProductTag = ProductTag(data["productTag"])
+        self.product_tag: ProductTag = ProductTag._from_str(data["productTag"])
 
         self.images: MaterialInstanceImages[HTTPClientT] = MaterialInstanceImages(data=data["images"], http=http)
 

--- a/fortnite_api/material.py
+++ b/fortnite_api/material.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
-from .enums import CosmeticCompatibleMode
+from .enums import CosmeticCompatibleMode, ProductTag
 from .http import HTTPClientT
 from .utils import get_with_fallback
 
@@ -126,6 +126,8 @@ class MaterialInstance(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         The ID of the Material instance.
     primary_mode: :class:`fortnite_api.CosmeticCompatibleMode`
         The primary mode of the Material instance. This denotes what the cosmetic material instance is compatible with.
+    product_tag: :class:`fortnite_api.ProductTag`
+        The product tag of the Material instance.
     images: :class:`fortnite_api.MaterialInstanceImages`
         Represents some images of the Material instance, as they are rendered in game.
     colors: Optional[:class:`fortnite_api.MaterialInstanceColors`]
@@ -146,6 +148,7 @@ class MaterialInstance(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
     __slots__: Tuple[str, ...] = (
         "id",
         "primary_mode",
+        "product_tag",
         "images",
         "colors",
         "scalings",
@@ -157,6 +160,7 @@ class MaterialInstance(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
 
         self.id: str = data["id"]
         self.primary_mode: CosmeticCompatibleMode = CosmeticCompatibleMode._from_str(data["primaryMode"])
+        self.product_tag: ProductTag = ProductTag(data["productTag"])
 
         self.images: MaterialInstanceImages[HTTPClientT] = MaterialInstanceImages(data=data["images"], http=http)
 

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -277,6 +277,7 @@ class ShopEntryLayout(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
 
         self.use_wide_preview: bool = data.get('useWidePreview', False)
         self.display_type: Optional[str] = data.get('displayType')
+        # Billboards include textureMetadata, stringMetadata and textMetadata
 
 
 class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -40,6 +40,7 @@ from .proxies import TransformerListProxy
 from .utils import get_with_fallback, parse_time
 
 __all__: Tuple[str, ...] = (
+    "ShopEntryOfferTag",
     "ShopEntryBundle",
     "ShopEntryBanner",
     "ShopEntryLayout",
@@ -142,6 +143,29 @@ class TileSize:
             height=int(match.group("height")),
             internal=value,
         )
+
+
+class ShopEntryOfferTag(ReconstructAble[Dict[str, Any], HTTPClientT]):
+    """
+    .. attributetable:: fortnite_api.ShopEntryOfferTag
+
+    Represents a shop entry offer tag. This class inherits from :class:`~fortnite_api.ReconstructAble`.
+
+    Attributes
+    ----------
+    id: :class:`str`
+        The ID of the offer tag.
+    text: :class:`str`
+        The text of the offer tag.
+    """
+
+    __slots__: Tuple[str, ...] = ("id", "text")
+
+    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+        super().__init__(data=data, http=http)
+
+        self.id: str = data["id"]
+        self.text: str = data["text"]
 
 
 class ShopEntryBundle(ReconstructAble[Dict[str, Any], HTTPClientT]):
@@ -461,6 +485,11 @@ class ShopEntry(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
         self.in_date: datetime.datetime = parse_time(data["inDate"])
         self.out_date: datetime.datetime = parse_time(data["outDate"])
+
+        _offer_tag = data.get("offerTag")
+        self.offer_tag: Optional[ShopEntryOfferTag[HTTPClientT]] = _offer_tag and ShopEntryOfferTag(
+            data=_offer_tag, http=http
+        )
 
         _bundle = data.get("bundle")
         self.bundle: Optional[ShopEntryBundle[HTTPClientT]] = _bundle and ShopEntryBundle(data=_bundle, http=http)

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -238,6 +238,8 @@ class ShopEntryLayout(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         The category of the layout, if any.
     index: :class:`int`
         The index of the layout.
+    rank: :class:`int`
+        The rank of the layout used for sorting.
     show_ineligible_offers: :class:`str`
         Whether ineligible offers are displayed in the layout or not.
     background: Optional[:class:`fortnite_api.Asset`]
@@ -253,6 +255,7 @@ class ShopEntryLayout(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         "name",
         "category",
         "index",
+        "rank",
         "show_ineligible_offers",
         "background",
         'use_wide_preview',
@@ -265,6 +268,7 @@ class ShopEntryLayout(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.name: str = data["name"]
         self.category: Optional[str] = data.get("category")
         self.index: int = data["index"]
+        self.rank: int = data["rank"]
         self.show_ineligible_offers: str = data["showIneligibleOffers"]
 
         _background = data.get("background")

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -281,7 +281,7 @@ class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 class ShopEntryRenderImage(ReconstructAble[Dict[str, Any], HTTPClientT]):
     """
-    .. attributetable:: fortnite_api.RenderImage
+    .. attributetable:: fortnite_api.ShopEntryRenderImage
 
     Represents a render image for a shop entry. A render image is an image
     used to visually represent a cosmetic item in the shop. This class inherits
@@ -323,7 +323,7 @@ class ShopEntryNewDisplayAsset(Hashable, ReconstructAble[Dict[str, Any], HTTPCli
         The ID of the cosmetic item associated with the display asset, if any.
     material_instances: List[:class:`fortnite_api.MaterialInstance`]
         A list of material instances used by the display asset.
-    render_images: List[:class:`fortnite_api.RenderImage`]
+    render_images: List[:class:`fortnite_api.ShopEntryRenderImage`]
         A list of render images used by the display asset.
     """
 

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -460,6 +460,7 @@ class ShopEntry(ReconstructAble[Dict[str, Any], HTTPClientT]):
         "final_price",
         "in_date",
         "out_date",
+        "offer_tag",
         "bundle",
         "banner",
         "giftable",

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -302,7 +302,7 @@ class ShopEntryRenderImage(ReconstructAble[Dict[str, Any], HTTPClientT]):
     def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
-        self.product_tag: ProductTag = ProductTag(data["productTag"])
+        self.product_tag: ProductTag = ProductTag._from_str(data["productTag"])
         self.file_name: str = data["fileName"]
         self.image: Asset[HTTPClientT] = Asset(url=data["image"], http=http)
 

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -258,7 +258,8 @@ class ShopEntryLayout(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         "rank",
         "show_ineligible_offers",
         "background",
-        'use_wide_preview',
+        "use_wide_preview",
+        "display_type",
     )
 
     def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -294,7 +294,7 @@ class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The second color of background gradient. If not present, the gradient only consists of two colors.
     color3: :class:`str`
         The third color of background gradient.
-    text_background_color: Optional[:class:`str`]Optional[:class:`str`]
+    text_background_color: Optional[:class:`str`]
         The fade out overlaying gradient color on which the text is displayed.
     """
 

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -286,7 +286,7 @@ class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
     Attributes
     ----------
-    color1: Optional[:class:`str`]
+    color1: :class:`str`
         The first color of background gradient.
     color2: Optional[:class:`str`]
         The second color of background gradient. If not present, the gradient only consists of two colors.
@@ -301,7 +301,7 @@ class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
     def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
-        self.color1: Optional[str] = data.get('color1')
+        self.color1: str = data['color1']
         self.color2: Optional[str] = data.get('color2')
         self.color3: str = data['color3']
         self.text_background_color: str = data['textBackgroundColor']

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -422,6 +422,9 @@ class ShopEntry(ReconstructAble[Dict[str, Any], HTTPClientT]):
             _new_display_asset and ShopEntryNewDisplayAsset(data=data["newDisplayAsset"], http=http)
         )
 
+        _colors = data.get("colors")
+        self.colors: Optional[ShopEntryColors] = _colors and ShopEntryColors(data=_colors, http=http)
+
         self.br: List[CosmeticBr[HTTPClientT]] = TransformerListProxy(
             get_with_fallback(data, "brItems", list),
             transform_data=lambda d: CosmeticBr(data=d, http=http),

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -286,7 +286,7 @@ class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
     Attributes
     ----------
-    color1: :class:`str`
+    color1: Optional[:class:`str`]
         The first color of background gradient.
     color2: Optional[:class:`str`]
         The second color of background gradient. If not present, the gradient only consists of two colors.
@@ -301,7 +301,7 @@ class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
     def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
-        self.color1: str = data['color1']
+        self.color1: Optional[str] = data.get('color1')
         self.color2: Optional[str] = data.get('color2')
         self.color3: str = data['color3']
         self.text_background_color: str = data['textBackgroundColor']

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -417,6 +417,8 @@ class ShopEntry(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The date when this entry was added to the shop.
     out_date: :class:`datetime.datetime`
         The date when this entry will be removed from the shop.
+    offer_tag: Optional[:class:`fortnite_api.ShopEntryOfferTag`]
+        The offer tag of this entry, if any.
     bundle: Optional[:class:`fortnite_api.ShopEntryBundle`]
         The bundle that this entry belongs to, if any.
     banner: Optional[:class:`fortnite_api.ShopEntryBanner`]

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -145,7 +145,7 @@ class TileSize:
         )
 
 
-class ShopEntryOfferTag(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class ShopEntryOfferTag(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.ShopEntryOfferTag
 

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -322,7 +322,7 @@ class ShopEntryRenderImage(ReconstructAble[Dict[str, Any], HTTPClientT]):
     product_tag: :class:`fortnite_api.ProductTag`
         The product tag of the render image.
     file_name: :class:`str`
-        The file name of the render image.
+        The internal file name of the rendered image. Refers to the name within the game files and **not** the :attr`image`. An example of this is ``T-Featured-Pickaxes-SleepyTimePickaxe``.
     image: :class:`fortnite_api.Asset`
         The image of the render image.
     """

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -274,7 +274,7 @@ class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         self.color1: str = data['color1']
-        self.color2: Optional[str] = data['color2']
+        self.color2: Optional[str] = data.get('color2')
         self.color3: str = data['color3']
         self.text_background_color: str = data['textBackgroundColor']
 

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -292,7 +292,7 @@ class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The second color of background gradient. If not present, the gradient only consists of two colors.
     color3: :class:`str`
         The third color of background gradient.
-    text_background_color: :class:`str`
+    text_background_color: Optional[:class:`str`]Optional[:class:`str`]
         The fade out overlaying gradient color on which the text is displayed.
     """
 
@@ -304,7 +304,7 @@ class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.color1: str = data['color1']
         self.color2: Optional[str] = data.get('color2')
         self.color3: str = data['color3']
-        self.text_background_color: str = data['textBackgroundColor']
+        self.text_background_color: Optional[str] = data.get('textBackgroundColor')
 
 
 class ShopEntryRenderImage(ReconstructAble[Dict[str, Any], HTTPClientT]):

--- a/tests/test_async_methods.py
+++ b/tests/test_async_methods.py
@@ -410,11 +410,6 @@ async def test_async_fetch_shop(api_key: str):
             assert offer_tag.id
             assert offer_tag.text
 
-        offer_tag = entry.offer_tag
-        if offer_tag:
-            assert isinstance(offer_tag, fn_api.ShopEntryOfferTag)
-            assert offer_tag.id
-            assert offer_tag.text
 
         bundle = entry.bundle
         if bundle:

--- a/tests/test_async_methods.py
+++ b/tests/test_async_methods.py
@@ -446,7 +446,6 @@ async def test_async_fetch_shop(api_key: str):
         if colors:
             assert isinstance(colors, fn_api.ShopEntryColors)
             assert isinstance(colors.color1, str)
-            assert colors.color2
             assert isinstance(colors.color3, str)
             assert isinstance(colors.text_background_color, str)
 

--- a/tests/test_async_methods.py
+++ b/tests/test_async_methods.py
@@ -464,7 +464,6 @@ async def test_async_fetch_shop(api_key: str):
             assert isinstance(colors, fn_api.ShopEntryColors)
             assert isinstance(colors.color1, str)
             assert isinstance(colors.color3, str)
-            assert isinstance(colors.text_background_color, str)
 
         for cosmetic in entry.br + entry.tracks + entry.instruments + entry.cars + entry.lego_kits:
             assert isinstance(cosmetic, fn_api.Cosmetic)

--- a/tests/test_async_methods.py
+++ b/tests/test_async_methods.py
@@ -410,7 +410,6 @@ async def test_async_fetch_shop(api_key: str):
             assert offer_tag.id
             assert offer_tag.text
 
-
         bundle = entry.bundle
         if bundle:
             assert isinstance(entry.bundle, fn_api.ShopEntryBundle)

--- a/tests/test_async_methods.py
+++ b/tests/test_async_methods.py
@@ -400,10 +400,6 @@ async def test_async_fetch_shop(api_key: str):
         assert entry.in_date
         assert entry.out_date
 
-        tile_size = entry.tile_size
-        assert isinstance(tile_size, fn_api.TileSize)
-        assert tile_size.internal == f'Size_{tile_size.width}_x_{tile_size.height}'
-
         bundle = entry.bundle
         if bundle:
             assert isinstance(entry.bundle, fn_api.ShopEntryBundle)
@@ -421,6 +417,10 @@ async def test_async_fetch_shop(api_key: str):
         assert isinstance(entry.refundable, bool)
         assert isinstance(entry.sort_priority, int)
         assert isinstance(entry.layout_id, str)
+
+        tile_size = entry.tile_size
+        assert isinstance(tile_size, fn_api.TileSize)
+        assert tile_size.internal == f'Size_{tile_size.width}_x_{tile_size.height}'
 
         layout = entry.layout
         if layout:
@@ -441,6 +441,14 @@ async def test_async_fetch_shop(api_key: str):
 
             for material_instance in new_display_asset.material_instances:
                 assert isinstance(material_instance, fn_api.MaterialInstance)
+
+        colors = entry.colors
+        if colors:
+            assert isinstance(colors, fn_api.ShopEntryColors)
+            assert isinstance(colors.color1, str)
+            assert colors.color2
+            assert isinstance(colors.color3, str)
+            assert isinstance(colors.text_background_color, str)
 
         for cosmetic in entry.br + entry.tracks + entry.instruments + entry.cars + entry.lego_kits:
             assert isinstance(cosmetic, fn_api.Cosmetic)

--- a/tests/test_async_methods.py
+++ b/tests/test_async_methods.py
@@ -366,6 +366,7 @@ async def test_async_beta_fetch_material_instances(api_key: str):
 
         assert instance.id
         assert instance.primary_mode
+        assert instance.product_tag
 
         # Walk through all the images and ensure they are assets
         for name, asset in instance.images.items():

--- a/tests/test_async_methods.py
+++ b/tests/test_async_methods.py
@@ -440,6 +440,7 @@ async def test_async_fetch_shop(api_key: str):
             assert layout.id
             assert layout.name
             assert isinstance(layout.index, int)
+            assert isinstance(layout.rank, int)
             assert layout.show_ineligible_offers
 
         assert entry.dev_name

--- a/tests/test_async_methods.py
+++ b/tests/test_async_methods.py
@@ -400,6 +400,18 @@ async def test_async_fetch_shop(api_key: str):
         assert entry.in_date
         assert entry.out_date
 
+        offer_tag = entry.offer_tag
+        if offer_tag:
+            assert isinstance(offer_tag, fn_api.ShopEntryOfferTag)
+            assert offer_tag.id
+            assert offer_tag.text
+
+        offer_tag = entry.offer_tag
+        if offer_tag:
+            assert isinstance(offer_tag, fn_api.ShopEntryOfferTag)
+            assert offer_tag.id
+            assert offer_tag.text
+
         bundle = entry.bundle
         if bundle:
             assert isinstance(entry.bundle, fn_api.ShopEntryBundle)

--- a/tests/test_sync_methods.py
+++ b/tests/test_sync_methods.py
@@ -382,7 +382,6 @@ def test_sync_fetch_shop(api_key: str):
         if colors:
             assert isinstance(colors, fn_api.ShopEntryColors)
             assert isinstance(colors.color1, str)
-            assert colors.color2
             assert isinstance(colors.color3, str)
             assert isinstance(colors.text_background_color, str)
 

--- a/tests/test_sync_methods.py
+++ b/tests/test_sync_methods.py
@@ -336,10 +336,6 @@ def test_sync_fetch_shop(api_key: str):
         assert entry.in_date
         assert entry.out_date
 
-        tile_size = entry.tile_size
-        assert isinstance(tile_size, fn_api.TileSize)
-        assert tile_size.internal == f'Size_{tile_size.width}_x_{tile_size.height}'
-
         bundle = entry.bundle
         if bundle:
             assert isinstance(entry.bundle, fn_api.ShopEntryBundle)
@@ -357,6 +353,10 @@ def test_sync_fetch_shop(api_key: str):
         assert isinstance(entry.refundable, bool)
         assert isinstance(entry.sort_priority, int)
         assert isinstance(entry.layout_id, str)
+
+        tile_size = entry.tile_size
+        assert isinstance(tile_size, fn_api.TileSize)
+        assert tile_size.internal == f'Size_{tile_size.width}_x_{tile_size.height}'
 
         layout = entry.layout
         if layout:
@@ -377,6 +377,14 @@ def test_sync_fetch_shop(api_key: str):
 
             for material_instance in new_display_asset.material_instances:
                 assert isinstance(material_instance, fn_api.MaterialInstance)
+
+        colors = entry.colors
+        if colors:
+            assert isinstance(colors, fn_api.ShopEntryColors)
+            assert isinstance(colors.color1, str)
+            assert colors.color2
+            assert isinstance(colors.color3, str)
+            assert isinstance(colors.text_background_color, str)
 
         for cosmetic in entry.br + entry.tracks + entry.instruments + entry.cars + entry.lego_kits:
             assert isinstance(cosmetic, fn_api.Cosmetic)

--- a/tests/test_sync_methods.py
+++ b/tests/test_sync_methods.py
@@ -364,6 +364,7 @@ def test_sync_fetch_shop(api_key: str):
             assert layout.id
             assert layout.name
             assert isinstance(layout.index, int)
+            assert isinstance(layout.rank, int)
             assert layout.show_ineligible_offers
 
         assert entry.dev_name

--- a/tests/test_sync_methods.py
+++ b/tests/test_sync_methods.py
@@ -303,6 +303,7 @@ def test_sync_beta_fetch_material_instances(api_key: str):
 
         assert instance.id
         assert instance.primary_mode
+        assert instance.product_tag
 
         # Walk through all the images and ensure they are assets
         for name, asset in instance.images.items():

--- a/tests/test_sync_methods.py
+++ b/tests/test_sync_methods.py
@@ -384,7 +384,6 @@ def test_sync_fetch_shop(api_key: str):
             assert isinstance(colors, fn_api.ShopEntryColors)
             assert isinstance(colors.color1, str)
             assert isinstance(colors.color3, str)
-            assert isinstance(colors.text_background_color, str)
 
         for cosmetic in entry.br + entry.tracks + entry.instruments + entry.cars + entry.lego_kits:
             assert isinstance(cosmetic, fn_api.Cosmetic)


### PR DESCRIPTION
This pull requests adds support for the following:
- `MaterialInstance.product_tag`
- `ShopEntry.colors` and `ShopEntry.offer_tag`
- `ShopEntryLayout.rank`
- `ShopEntryNewDisplayAsset.render_images`
It also introduces the following new objects:
- `ShopEntryRenderImage`
- `ShopEntryColors`
- `ShopEntryOfferTag`
- `ProductTag`