### PR TITLE
Add changelog for v3.1.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,18 +9,36 @@ Changelog
 
 v3.1.0
 -------
+This version introduces new data for shop-related objects, reflecting the updated shop layouts and the Fortnite webshop. Additionally, it includes functions that were omitted in version 3.0.0 and addresses a design decision that results in a breaking change.
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+- ``ShopEntryNewDisplayAsset`` has been renamed to :class:`fortnite_api.NewDisplayAsset`.
+- ``Banner.colour`` has been removed as it was merely an alias for :attr:`fortnite_api.Banner.color`.
 
 New Features
+~~~~~~~~~~~~
+- Added new object :class:`fortnite_api.ProductTag`.
+- Added attribute :attr:`fortnite_api.MaterialInstance.product_tag`.
+- Added new object :class:`fortnite_api.ShopEntryOfferTag`.
+- Added new object :class:`fortnite_api.ShopEntryColors`.
+- Added new object :class:`fortnite_api.RenderImage`.
+- Added attribute :attr:`fortnite_api.ShopEntryLayout.rank`.
+- Added attribute :attr:`fortnite_api.NewDisplayAsset.render_images`.
+- Added attribute :attr:`fortnite_api.ShopEntry.offer_tag`.
+- Added attribute :attr:`fortnite_api.ShopEntry.colors`.
+
+Bug Fixes
+~~~~~~~~~
+- Fetching specific game mode news when no news is available now raises :class:`fortnite_api.NotFound` instead of :class:`fortnite_api.ServiceUnavailable`, thanks to proper handling from Fortnite-API.com. Documentation has been updated accordingly.
+- Fixed an issue where ``type`` and ``time_window`` parameters were not respected when fetching stats.
+- :attr:`fortnite_api.Playlist.images` now returns ``None`` when no images are available, instead of an empty dict.
+- Ensured all datetime objects include timezone information to avoid returning naive datetime objects in rare cases.
+
+Miscellaneous
 ~~~~~~~~~~~~~
-- Add :attr:`fortnite_api.MaterialInstance.product_tag`
-- Add :attr:`fortnite_api.ShopEntry.colors`
-- Add :attr:`fortnite_api.ShopEntry.offer_tag`
-- Add :attr:`fortnite_api.ShopEntryLayout.rank`
-- Add :attr:`fortnite_api.ShopEntryNewDisplayAsset.render_images`
-- Create new object :class:`fortnite_api.ShopEntryRenderImage`
-- Create new object :class:`fortnite_api.ShopEntryColors`
-- Create new object :class:`fortnite_api.ShopEntryOfferTag`
-- Create new object :class:`fortnite_api.ProductTag`
+- Improved documentation for attributes that require specific response flags to be set.
+
 
 .. _vp3p0p0:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,12 +9,12 @@ Changelog
 
 v3.1.0
 -------
-This version introduces new data for shop-related objects, reflecting the updated shop layouts and the Fortnite webshop. Additionally, it includes functions that were omitted in version 3.0.0 and addresses a design decision that results in a breaking change.
+This version introduces new data for shop-related objects, reflecting the updated shop layouts and the Fortnite webshop. Additionally, it includes functions that were omitted in version v3.0.0 and addresses a design decision that results in a breaking change.
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 - ``ShopEntryNewDisplayAsset`` has been renamed to :class:`fortnite_api.NewDisplayAsset`.
-- ``BannerColor.colour`` has been removed as it was merely an alias for :attr:`fortnite_api.BannerColor.color`.
+- Alias ``BannerColor.colour`` has been removed for consistency. The API does not use aliases, use  attr:`fortnite_api.BannerColor.color` instead.
 
 New Features
 ~~~~~~~~~~~~
@@ -32,17 +32,16 @@ Bug Fixes
 ~~~~~~~~~
 - Fixed an issue where ``type`` and ``time_window`` parameters were not respected when fetching stats.
 - :attr:`fortnite_api.Playlist.images` now returns ``None`` when no images are available, instead of an empty dict.
-- Ensured all datetime objects include timezone information to avoid returning naive datetime objects in rare cases.
+- Bug fix for returning naive datetime objects in rare cases. All datetime objects are UTC aware.
 
 Documentation
 ~~~~~~~~~~~~~
 - Added :ref:`response flags <response_flags>` documentation to explain how to use the ``fortnite_api.ResponseFlags`` class, how to enable response flags, which response flags are available, and when you should enable them.
-- Added ``opt-in`` directive on attributes that require a specific response flag to be set. This is to ensure users are aware of the response flags required to access certain attributes when using the API.
+- Added ``opt-in`` directive in the documentation on attributes that require a specific response flag to be set. This ensures users know of the response flags required to access certain attributes when using the API.
 
 Miscellaneous
 ~~~~~~~~~~~~~
-- Fetching specific game mode news raised :class:`fortnite_api.ServiceUnavailable`, due to improper handling from Fortnite-API.com. This has been fixed within the API. Now, when no news is available, :class:`fortnite_api.NotFound` is raised instead. This change is reflected in the documentation.
-- Improved documentation for attributes that require specific response flags to be set.
+- Previously, fetching specific game mode news raised :class:`fortnite_api.ServiceUnavailable` due to improper handling from Fortnite-API.com. This has been fixed within the API. Now, when no news is available, :class:`fortnite_api.NotFound` is raised instead. This change is also reflected in the documentation.
 
 
 .. _vp3p0p0:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,7 @@ This version introduces new data for shop-related objects, reflecting the update
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 - ``ShopEntryNewDisplayAsset`` has been renamed to :class:`fortnite_api.NewDisplayAsset`.
-- ``Banner.colour`` has been removed as it was merely an alias for :attr:`fortnite_api.Banner.color`.
+- ``BannerColor.colour`` has been removed as it was merely an alias for :attr:`fortnite_api.BannerColor.color`.
 
 New Features
 ~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,11 @@ Bug Fixes
 - :attr:`fortnite_api.Playlist.images` now returns ``None`` when no images are available, instead of an empty dict.
 - Ensured all datetime objects include timezone information to avoid returning naive datetime objects in rare cases.
 
+Documentation
+~~~~~~~~~~~~~
+- Added :ref:`response flags <response_flags>` documentation to explain how to use the ``fortnite_api.ResponseFlags`` class, how to enable response flags, which response flags are available, and when you should enable them.
+- Added ``opt-in`` directive on attributes that require a specific response flag to be set. This is to ensure users are aware of the response flags required to access certain attributes when using the API.
+
 Miscellaneous
 ~~~~~~~~~~~~~
 - Fetching specific game mode news raised :class:`fortnite_api.ServiceUnavailable`, due to improper handling from Fortnite-API.com. This has been fixed within the API. Now, when no news is available, :class:`fortnite_api.NotFound` is raised instead. This change is reflected in the documentation.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,29 @@
+.. currentmodule:: fortnite_api
+
 .. _changelog:
 
 Changelog
 =========
-This page keeps track of all the changes to the project. For help on Migrating to Version 3 from Version 2, see the :ref:`Migration guide <migrating>`.
+
+.. _vp3p1p0:
+
+v3.1.0
+-------
+
+New Features
+~~~~~~~~~~~~~
+- Add :attr:`fortnite_api.MaterialInstance.product_tag`
+- Add :attr:`fortnite_api.ShopEntry.colors`
+- Add :attr:`fortnite_api.ShopEntry.offer_tag`
+- Add :attr:`fortnite_api.ShopEntryLayout.rank`
+- Add :attr:`fortnite_api.ShopEntryNewDisplayAsset.render_images`
+- Create new object :class:`fortnite_api.ShopEntryRenderImage`
+- Create new object :class:`fortnite_api.ShopEntryColors`
+- Create new object :class:`fortnite_api.ShopEntryOfferTag`
+- Create new object :class:`fortnite_api.ProductTag`
+
+.. _vp3p0p0:
+
+v3.0.0
+-------
+For help on Migrating to Version 3 from Version 2, and a complete list of all the new features, see the :ref:`Migration guide <migrating>`.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,13 +30,13 @@ New Features
 
 Bug Fixes
 ~~~~~~~~~
-- Fetching specific game mode news when no news is available now raises :class:`fortnite_api.NotFound` instead of :class:`fortnite_api.ServiceUnavailable`, thanks to proper handling from Fortnite-API.com. Documentation has been updated accordingly.
 - Fixed an issue where ``type`` and ``time_window`` parameters were not respected when fetching stats.
 - :attr:`fortnite_api.Playlist.images` now returns ``None`` when no images are available, instead of an empty dict.
 - Ensured all datetime objects include timezone information to avoid returning naive datetime objects in rare cases.
 
 Miscellaneous
 ~~~~~~~~~~~~~
+- Fetching specific game mode news raised :class:`fortnite_api.ServiceUnavailable`, due to improper handling from Fortnite-API.com. This has been fixed within the API. Now, when no news is available, :class:`fortnite_api.NotFound` is raised instead. This change is reflected in the documentation.
 - Improved documentation for attributes that require specific response flags to be set.
 
 


### PR DESCRIPTION
PR adds the changelog for the upcoming `v3.1.0` update to the library.

Conventionally, it is the PR's responsibility to update the changelog; but, because this was accidentally missed, this PR has been created as a one-time exception for updating the documentation for any new changes. 

PR status as of October 19th, 2024:
- [x] Waiting on #28 to be merged beforehand.