### PR TITLE
Remove alias `colour` for `color`

### DIFF
--- a/fortnite_api/banner.py
+++ b/fortnite_api/banner.py
@@ -141,8 +141,6 @@ class BannerColor(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         The id of the color.
     color: :class:`str`
         The color of the banner.
-    colour: :class:`str`
-        An alias to :attr:`~color`.
     category: :class:`str`
         The category of the banner.
     sub_category_group: :class:`int`
@@ -156,7 +154,6 @@ class BannerColor(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.id: str = data["id"]
 
         self.color: str = data["color"]
-        self.colour = self.color
 
         self.category: str = data["category"]
         self.sub_category_group: int = data["subCategoryGroup"]  # TODO: Convert this to enum?


### PR DESCRIPTION
## Summary

This pull request removes the alias `colour` for `color`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
