### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip" # Cache the pip packages to speed up the workflow
 
       - name: Install Dependencies and Package

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install Dependencies
         run: python -m pip install -U pip setuptools build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip" # Cache the pip packages to speed up the workflow
 
       - name: Install Dependencies and Package
@@ -45,10 +45,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip" # Cache the pip packages to speed up the workflow
 
       - name: Install Dependencies and Project
@@ -69,10 +69,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.8
+      - name: Setup Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip" # Cache the pip packages to speed up the workflow
 
       - name: Install Dependencies and Project

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The library's focus is to provide a simple and easy-to-use interface to interact
 
 ## Installation
 
-Note that **Python 3.8 or higher is required.**
+Note that **Python 3.9 or higher is required.**
 
 ```sh
 # Linux/macOS

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,16 @@
 Changelog
 =========
 
+.. _vp3p2p0:
+
+v3.2.0
+-------
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+- Drop support for Python 3.8. The minimum supported Python version is now 3.9.
+
+
 .. _vp3p1p0:
 
 v3.1.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@
 import os
 import re
 import sys
-from typing import Any, Dict
+from typing import Any
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -159,7 +159,7 @@ resource_links = {
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options: Dict[str, Any] = {
+html_theme_options: dict[str, Any] = {
     "source_repository": "https://github.com/Fortnite-API/py-wrapper",
     "source_branch": "main",
 }

--- a/docs/extensions/attribute_table.py
+++ b/docs/extensions/attribute_table.py
@@ -27,7 +27,8 @@ from __future__ import annotations
 import importlib
 import inspect
 import re
-from typing import TYPE_CHECKING, ClassVar, Dict, List, NamedTuple, Optional, Sequence, Tuple
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, ClassVar, NamedTuple, Optional
 
 from docutils import nodes
 from sphinx import addnodes
@@ -124,7 +125,7 @@ class PyAttributeTable(SphinxDirective):
     final_argument_whitespace = False
     option_spec: ClassVar[OptionSpec] = {}  # type: ignore
 
-    def parse_name(self, content: str) -> Tuple[str, str]:
+    def parse_name(self, content: str) -> tuple[str, str]:
         match = _name_parser_regex.match(content)
         if match is None:
             raise RuntimeError(f"content {content} somehow doesn't match regex in {self.env.docname}.")
@@ -140,7 +141,7 @@ class PyAttributeTable(SphinxDirective):
 
         return modulename, name
 
-    def run(self) -> List[attributetableplaceholder]:
+    def run(self) -> list[attributetableplaceholder]:
         """If you're curious on the HTML this is meant to generate:
 
         <div class="py-attribute-table">
@@ -177,10 +178,10 @@ class PyAttributeTable(SphinxDirective):
         return [node]
 
 
-def build_lookup_table(env: BuildEnvironment) -> Dict[str, List[str]]:
+def build_lookup_table(env: BuildEnvironment) -> dict[str, list[str]]:
     # Given an environment, load up a lookup table of
     # full-class-name: objects
-    result: Dict[str, List[str]] = {}
+    result: dict[str, list[str]] = {}
     domain = env.domains['py']
 
     ignored = {
@@ -231,12 +232,12 @@ def process_attributetable(app: Sphinx, doctree: nodes.Node, fromdocname: str) -
 
 
 def get_class_results(
-    lookup: Dict[str, List[str]], modulename: str, name: str, fullname: str
-) -> Dict[str, List[TableElement]]:
+    lookup: dict[str, list[str]], modulename: str, name: str, fullname: str
+) -> dict[str, list[TableElement]]:
     module = importlib.import_module(modulename)
     cls = getattr(module, name)
 
-    groups: Dict[str, List[TableElement]] = {
+    groups: dict[str, list[TableElement]] = {
         _('Attributes'): [],
         _('Methods'): [],
     }

--- a/docs/extensions/opt_in.py
+++ b/docs/extensions/opt_in.py
@@ -24,7 +24,8 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
 
 from docutils import nodes
 from docutils.parsers import rst

--- a/docs/extensions/outdated_code_blocks.py
+++ b/docs/extensions/outdated_code_blocks.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import ClassVar, List
+from typing import ClassVar
 
 from docutils.nodes import Element, Node, TextElement
 from docutils.parsers.rst import directives
@@ -117,12 +117,12 @@ class OutdatedCodeBlock(CodeBlock):
         'name': directives.unchanged,
     }
 
-    def run(self) -> List[Node]:
+    def run(self) -> list[Node]:
 
         # Create the main node that holds the code block and warning
         root = OutdatedCodeBlockNode()
 
-        code_block: List[Node] = super().run()
+        code_block: list[Node] = super().run()
         root += code_block
 
         # Create the underlying warning node

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ To install the Fortnite-API Python library, you can use pip. Run the following c
 
 .. note::
 
-   Note that Python 3.8 and greater is required to use this library.
+   Note that Python 3.9 and greater is required to use this library.
 
 .. code-block:: bash
 

--- a/fortnite_api/abc.py
+++ b/fortnite_api/abc.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Generic, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Generic, TypeVar, Union
 
 from typing_extensions import Self
 
@@ -36,7 +36,7 @@ DictT = TypeVar('DictT', bound='Mapping[Any, Any]')
 if TYPE_CHECKING:
     from .client import Client, SyncClient
 
-__all__: Tuple[str, ...] = ('IdComparable', 'Hashable', 'ReconstructAble')
+__all__: tuple[str, ...] = ('IdComparable', 'Hashable', 'ReconstructAble')
 
 
 class IdComparable:
@@ -115,7 +115,7 @@ class ReconstructAble(Generic[DictT, HTTPClientT]):
     # still keeping the correct HTTPClient type.
 
     @classmethod
-    def from_dict(cls: Type[Self], data: DictT, *, client: Union[Client, SyncClient]) -> Self:
+    def from_dict(cls: type[Self], data: DictT, *, client: Union[Client, SyncClient]) -> Self:
         """Reconstructs this class from a raw dictionary object. This is useful for when you
         store the raw data and want to reconstruct the object later on.
 

--- a/fortnite_api/abc.py
+++ b/fortnite_api/abc.py
@@ -34,6 +34,7 @@ from .http import HTTPClient, HTTPClientT, SyncHTTPClient
 DictT = TypeVar('DictT', bound='Mapping[Any, Any]')
 
 if TYPE_CHECKING:
+    from typing import Mapping, Any
     from .client import Client, SyncClient
 
 __all__: tuple[str, ...] = ('IdComparable', 'Hashable', 'ReconstructAble')
@@ -130,12 +131,12 @@ class ReconstructAble(Generic[DictT, HTTPClientT]):
             # Whenever the client is a SyncClient, we can safely assume that the http
             # attribute is a SyncHTTPClient, as this is the only HTTPClientT possible.
             sync_http: SyncHTTPClient = client.http
-            return cls(data=data, http=sync_http)
+            return cls(data=data, http=sync_http)  # type: ignore # Pyright cannot infer the type of cls
         else:
             # Whenever the client is a Client, we can safely assume that the http
             # attribute is a HTTPClient, as this is the only HTTPClientT possible.
             http: HTTPClient = client.http
-            return cls(data=data, http=http)
+            return cls(data=data, http=http)  # type: ignore # Pyright cannot infer the type of cls
 
     def to_dict(self) -> DictT:
         """Turns this object into a raw dictionary object. This is useful for when you

--- a/fortnite_api/abc.py
+++ b/fortnite_api/abc.py
@@ -34,7 +34,8 @@ from .http import HTTPClient, HTTPClientT, SyncHTTPClient
 DictT = TypeVar('DictT', bound='Mapping[Any, Any]')
 
 if TYPE_CHECKING:
-    from typing import Mapping, Any
+    from typing import Any, Mapping
+
     from .client import Client, SyncClient
 
 __all__: tuple[str, ...] = ('IdComparable', 'Hashable', 'ReconstructAble')

--- a/fortnite_api/account.py
+++ b/fortnite_api/account.py
@@ -24,17 +24,17 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from .abc import Hashable, ReconstructAble
 from .http import HTTPClientT
 from .utils import simple_repr
 
-__all__: Tuple[str, ...] = ("Account",)
+__all__: tuple[str, ...] = ("Account",)
 
 
 @simple_repr
-class Account(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
+class Account(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.Account
 
@@ -60,12 +60,12 @@ class Account(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         The display name of the account.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "id",
         "name",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.id: str = data["id"]

--- a/fortnite_api/aes.py
+++ b/fortnite_api/aes.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 
 import dataclasses
 import re
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple, Union
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from .abc import ReconstructAble
 from .http import HTTPClientT
@@ -35,7 +36,7 @@ from .utils import parse_time, simple_repr
 if TYPE_CHECKING:
     import datetime
 
-__all__: Tuple[str, ...] = ("Aes", "DynamicKey", "Version")
+__all__: tuple[str, ...] = ("Aes", "DynamicKey", "Version")
 
 VERSION_REGEX: re.Pattern[str] = re.compile(r"(?P<version>[0-9]{2})\.(?P<subversion>[0-9]{2})")
 
@@ -88,7 +89,7 @@ class Version:
 
 
 @simple_repr
-class Aes(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class Aes(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.Aes
 
@@ -143,7 +144,7 @@ class Aes(ReconstructAble[Dict[str, Any], HTTPClientT]):
         All current dynamic keys
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "main_key",
         "build",
         "version",
@@ -151,7 +152,7 @@ class Aes(ReconstructAble[Dict[str, Any], HTTPClientT]):
         "dynamic_keys",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT):
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT):
         super().__init__(data=data, http=http)
 
         self.main_key: Optional[str] = data.get("mainKey")
@@ -164,7 +165,7 @@ class Aes(ReconstructAble[Dict[str, Any], HTTPClientT]):
             major, minor = version_info[0]
             self.version = Version(major=int(major), minor=int(minor))
 
-        self.dynamic_keys: List[DynamicKey[HTTPClientT]] = [
+        self.dynamic_keys: list[DynamicKey[HTTPClientT]] = [
             DynamicKey(data=entry, http=http) for entry in data.get("dynamicKeys", [])
         ]
         self.updated: datetime.datetime = parse_time(data["updated"])
@@ -189,7 +190,7 @@ class Aes(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class DynamicKey(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class DynamicKey(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.DynamicKey
 
@@ -227,9 +228,9 @@ class DynamicKey(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The key.
     """
 
-    __slots__: Tuple[str, ...] = ("pak_filename", "pak_guid", "key")
+    __slots__: tuple[str, ...] = ("pak_filename", "pak_guid", "key")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT):
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT):
         super().__init__(data=data, http=http)
 
         self.pak_filename: str = data["pakFilename"]

--- a/fortnite_api/all.py
+++ b/fortnite_api/all.py
@@ -23,16 +23,22 @@ SOFTWARE.
 """
 
 from collections.abc import Generator
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from .abc import ReconstructAble
-from .cosmetics import CosmeticBr, CosmeticCar, CosmeticInstrument, CosmeticLegoKit, CosmeticTrack, VariantBean, VariantLego
+from .cosmetics import (
+    CosmeticBr,
+    CosmeticCar,
+    CosmeticInstrument,
+    CosmeticLegoKit,
+    CosmeticTrack,
+    VariantBean,
+    VariantLego,
+    Cosmetic,
+)
 from .http import HTTPClientT
 from .proxies import TransformerListProxy
 from .utils import get_with_fallback, simple_repr
-
-if TYPE_CHECKING:
-    from .cosmetics import Cosmetic
 
 __all__: tuple[str, ...] = ("CosmeticsAll",)
 

--- a/fortnite_api/all.py
+++ b/fortnite_api/all.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from .abc import ReconstructAble
 from .cosmetics import (
+    Cosmetic,
     CosmeticBr,
     CosmeticCar,
     CosmeticInstrument,
@@ -34,7 +35,6 @@ from .cosmetics import (
     CosmeticTrack,
     VariantBean,
     VariantLego,
-    Cosmetic,
 )
 from .http import HTTPClientT
 from .proxies import TransformerListProxy

--- a/fortnite_api/all.py
+++ b/fortnite_api/all.py
@@ -22,13 +22,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from typing import Any
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any
 
 from .abc import ReconstructAble
 from .cosmetics import CosmeticBr, CosmeticCar, CosmeticInstrument, CosmeticLegoKit, CosmeticTrack, VariantBean, VariantLego
 from .http import HTTPClientT
 from .proxies import TransformerListProxy
 from .utils import get_with_fallback, simple_repr
+
+if TYPE_CHECKING:
+    from .cosmetics import Cosmetic
 
 __all__: tuple[str, ...] = ("CosmeticsAll",)
 
@@ -141,7 +145,7 @@ class CosmeticsAll(ReconstructAble[dict[str, Any], HTTPClientT]):
             lambda x: VariantBean(data=x, http=self._http),
         )
 
-    def __iter__(self):
+    def __iter__(self) -> Generator[Cosmetic[dict[str, Any], HTTPClientT], None, None]:
         yield from self.br
 
         yield from self.tracks
@@ -156,7 +160,7 @@ class CosmeticsAll(ReconstructAble[dict[str, Any], HTTPClientT]):
 
         yield from self.lego_kits
 
-    def __len__(self):
+    def __len__(self) -> int:
         return (
             len(self.br)
             + len(self.tracks)

--- a/fortnite_api/all.py
+++ b/fortnite_api/all.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from .abc import ReconstructAble
 from .cosmetics import CosmeticBr, CosmeticCar, CosmeticInstrument, CosmeticLegoKit, CosmeticTrack, VariantBean, VariantLego
@@ -30,11 +30,11 @@ from .http import HTTPClientT
 from .proxies import TransformerListProxy
 from .utils import get_with_fallback, simple_repr
 
-__all__: Tuple[str, ...] = ("CosmeticsAll",)
+__all__: tuple[str, ...] = ("CosmeticsAll",)
 
 
 @simple_repr
-class CosmeticsAll(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class CosmeticsAll(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticsAll
 
@@ -86,7 +86,7 @@ class CosmeticsAll(ReconstructAble[Dict[str, Any], HTTPClientT]):
         A list of all lego kit cosmetics.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "br",
         "tracks",
         "instruments",
@@ -96,7 +96,7 @@ class CosmeticsAll(ReconstructAble[Dict[str, Any], HTTPClientT]):
         "beans",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         _br = get_with_fallback(data, "br", list)
@@ -142,26 +142,19 @@ class CosmeticsAll(ReconstructAble[Dict[str, Any], HTTPClientT]):
         )
 
     def __iter__(self):
-        for br in self.br:
-            yield br
+        yield from self.br
 
-        for track in self.tracks:
-            yield track
+        yield from self.tracks
 
-        for instrument in self.instruments:
-            yield instrument
+        yield from self.instruments
 
-        for car in self.cars:
-            yield car
+        yield from self.cars
 
-        for lego in self.lego:
-            yield lego
+        yield from self.lego
 
-        for bean in self.beans:
-            yield bean
+        yield from self.beans
 
-        for lego_kit in self.lego_kits:
-            yield lego_kit
+        yield from self.lego_kits
 
     def __len__(self):
         return (

--- a/fortnite_api/asset.py
+++ b/fortnite_api/asset.py
@@ -24,7 +24,8 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Coroutine, Generic, Optional, Tuple, Union, overload
+from collections.abc import Coroutine
+from typing import TYPE_CHECKING, Any, Generic, Optional, Union, overload
 
 from typing_extensions import Self
 
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
     from .http import HTTPClient, SyncHTTPClient
 
 
-__all__: Tuple[str, ...] = ('Asset',)
+__all__: tuple[str, ...] = ('Asset',)
 
 
 class _AssetRoute(Route):
@@ -63,7 +64,7 @@ class Asset(Generic[HTTPClientT]):
             icon: bytes = await images.icon.read()
     """
 
-    __slots__: Tuple[str, ...] = ('_http', '_url', '_max_size', '_size')
+    __slots__: tuple[str, ...] = ('_http', '_url', '_max_size', '_size')
 
     def __init__(self, *, http: HTTPClientT, url: str, max_size: Optional[int] = MISSING, size: int = MISSING) -> None:
         self._http: HTTPClientT = http
@@ -89,7 +90,7 @@ class Asset(Generic[HTTPClientT]):
         return hash(self.url)
 
     def __repr__(self) -> str:
-        return '<Asset url={0.url!r}>'.format(self)
+        return f'<Asset url={self.url!r}>'
 
     @property
     def url(self) -> str:

--- a/fortnite_api/banner.py
+++ b/fortnite_api/banner.py
@@ -24,21 +24,21 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 from .abc import Hashable, ReconstructAble
 from .http import HTTPClientT
 from .images import Images
 from .utils import simple_repr
 
-__all__: Tuple[str, ...] = (
+__all__: tuple[str, ...] = (
     "Banner",
     "BannerColor",
 )
 
 
 @simple_repr
-class Banner(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
+class Banner(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.Banner
 
@@ -97,7 +97,7 @@ class Banner(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         Preview images of the banner.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "id",
         "name",
         "description",
@@ -107,7 +107,7 @@ class Banner(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         "images",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.id: str = data["id"]
@@ -121,7 +121,7 @@ class Banner(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class BannerColor(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
+class BannerColor(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.BannerColor
 
@@ -147,9 +147,9 @@ class BannerColor(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         The sub category group of the banner.
     """
 
-    __slots__: Tuple[str, ...] = ("id", "color", "category", "sub_category_group")
+    __slots__: tuple[str, ...] = ("id", "color", "category", "sub_category_group")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
         self.id: str = data["id"]
 

--- a/fortnite_api/client.py
+++ b/fortnite_api/client.py
@@ -27,11 +27,12 @@ from __future__ import annotations
 import datetime
 import functools
 import inspect
-from typing import Any, Callable, List, Literal, Optional, Tuple, TypeVar, Union, cast, overload
+from collections.abc import Coroutine
+from typing import Any, Callable, Literal, Optional, TypeVar, Union, cast, overload
 
 import aiohttp
 import requests
-from typing_extensions import Concatenate, Coroutine, ParamSpec
+from typing_extensions import Concatenate, ParamSpec
 
 from .aes import Aes
 from .all import CosmeticsAll
@@ -52,7 +53,7 @@ from .shop import Shop
 from .stats import BrPlayerStats
 from .utils import MISSING, _transform_dict_for_get_request, copy_doc, remove_prefix
 
-__all__: Tuple[str, ...] = (
+__all__: tuple[str, ...] = (
     'Client',
     'SyncClient',
 )
@@ -241,7 +242,7 @@ class Client:
 
     async def fetch_cosmetics_br(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[CosmeticBr]:
+    ) -> list[CosmeticBr]:
         """|coro|
 
         Fetches all Battle Royale cosmetics available in Fortnite.
@@ -275,7 +276,7 @@ class Client:
 
     async def fetch_cosmetics_cars(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[CosmeticCar]:
+    ) -> list[CosmeticCar]:
         """|coro|
 
         Fetches all Car cosmetics available in Fortnite.
@@ -309,7 +310,7 @@ class Client:
 
     async def fetch_cosmetics_instruments(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[CosmeticInstrument]:
+    ) -> list[CosmeticInstrument]:
         """|coro|
 
         Fetches all instrument cosmetics available in Fortnite.
@@ -343,7 +344,7 @@ class Client:
 
     async def fetch_cosmetics_lego_kits(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[CosmeticLegoKit]:
+    ) -> list[CosmeticLegoKit]:
         """|coro|
 
         Fetches all lego kit cosmetics available in Fortnite.
@@ -377,7 +378,7 @@ class Client:
 
     async def fetch_variants_lego(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[VariantLego]:
+    ) -> list[VariantLego]:
         """|coro|
 
         Fetches all lego cosmetic variants available in Fortnite.
@@ -412,7 +413,7 @@ class Client:
 
     async def fetch_variants_beans(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[VariantBean]:
+    ) -> list[VariantBean]:
         """|coro|
 
         Fetches all bean cosmetic variants available in Fortnite. For more information
@@ -448,7 +449,7 @@ class Client:
 
     async def fetch_cosmetics_tracks(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[CosmeticTrack]:
+    ) -> list[CosmeticTrack]:
         """|coro|
 
         Fetches all audio track cosmetics available in Fortnite.
@@ -597,7 +598,7 @@ class Client:
         added_since: Optional[datetime.datetime] = ...,
         unseen_for: Optional[int] = ...,
         last_appearance: Optional[datetime.datetime] = ...,
-    ) -> List[CosmeticBr]: ...
+    ) -> list[CosmeticBr]: ...
 
     @overload
     async def search_br_cosmetics(
@@ -640,7 +641,7 @@ class Client:
         last_appearance: Optional[datetime.datetime] = ...,
     ) -> CosmeticBr: ...
 
-    async def search_br_cosmetics(self, **kwargs: Any) -> Union[CosmeticBr, List[CosmeticBr]]:
+    async def search_br_cosmetics(self, **kwargs: Any) -> Union[CosmeticBr, list[CosmeticBr]]:
         """|coro|
 
         Searches all Battle Royale cosmetics available in Fortnite and returns
@@ -774,7 +775,7 @@ class Client:
         return Aes(data=data, http=self.http)
 
     # BANNERS
-    async def fetch_banners(self, *, language: Optional[GameLanguage] = MISSING) -> List[Banner]:
+    async def fetch_banners(self, *, language: Optional[GameLanguage] = MISSING) -> list[Banner]:
         """|coro|
 
         Fetch all banners available in Fortnite.
@@ -798,7 +799,7 @@ class Client:
             lambda x: Banner(data=x, http=self.http),
         )
 
-    async def fetch_banner_colors(self) -> List[BannerColor]:
+    async def fetch_banner_colors(self) -> list[BannerColor]:
         """|coro|
 
         Fetch all banner colors available in Fortnite.
@@ -939,7 +940,7 @@ class Client:
 
     # PLAYLISTS
 
-    async def fetch_playlists(self, /, *, language: Optional[GameLanguage] = MISSING) -> List[Playlist]:
+    async def fetch_playlists(self, /, *, language: Optional[GameLanguage] = MISSING) -> list[Playlist]:
         """|coro|
 
         Fetches a list of current playlists available in Fortnite.
@@ -1103,7 +1104,7 @@ class Client:
     # BETA METHODS
 
     @beta_method
-    async def beta_fetch_new_display_assets(self) -> List[NewDisplayAsset]:
+    async def beta_fetch_new_display_assets(self) -> list[NewDisplayAsset]:
         """|coro|
 
         Fetches all the new display assets available in Fortnite.
@@ -1153,7 +1154,7 @@ class Client:
         )
 
     @beta_method
-    async def beta_fetch_material_instances(self) -> List[MaterialInstance]:
+    async def beta_fetch_material_instances(self) -> list[MaterialInstance]:
         """|coro|
 
         Fetches all the material instances available in Fortnite.
@@ -1300,7 +1301,7 @@ class SyncClient:
     @copy_doc(Client.fetch_cosmetics_br)
     def fetch_cosmetics_br(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[CosmeticBr[SyncHTTPClient]]:
+    ) -> list[CosmeticBr[SyncHTTPClient]]:
         data = self.http.get_cosmetics_br(
             language=self._resolve_default_language_value(language),
             response_flags=self._resolve_response_flags_value(response_flags),
@@ -1313,7 +1314,7 @@ class SyncClient:
     @copy_doc(Client.fetch_cosmetics_cars)
     def fetch_cosmetics_cars(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[CosmeticCar[SyncHTTPClient]]:
+    ) -> list[CosmeticCar[SyncHTTPClient]]:
         data = self.http.get_cosmetics_cars(
             language=self._resolve_default_language_value(language),
             response_flags=self._resolve_response_flags_value(response_flags),
@@ -1326,7 +1327,7 @@ class SyncClient:
     @copy_doc(Client.fetch_cosmetics_instruments)
     def fetch_cosmetics_instruments(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[CosmeticInstrument[SyncHTTPClient]]:
+    ) -> list[CosmeticInstrument[SyncHTTPClient]]:
         data = self.http.get_cosmetics_instruments(
             language=self._resolve_default_language_value(language),
             response_flags=self._resolve_response_flags_value(response_flags),
@@ -1339,7 +1340,7 @@ class SyncClient:
     @copy_doc(Client.fetch_cosmetics_lego_kits)
     def fetch_cosmetics_lego_kits(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[CosmeticLegoKit[SyncHTTPClient]]:
+    ) -> list[CosmeticLegoKit[SyncHTTPClient]]:
         data = self.http.get_cosmetics_lego_kits(
             language=self._resolve_default_language_value(language),
             response_flags=self._resolve_response_flags_value(response_flags),
@@ -1352,7 +1353,7 @@ class SyncClient:
     @copy_doc(Client.fetch_variants_lego)
     def fetch_variants_lego(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[VariantLego[SyncHTTPClient]]:
+    ) -> list[VariantLego[SyncHTTPClient]]:
         data = self.http.get_cosmetics_lego(
             language=self._resolve_default_language_value(language),
             response_flags=self._resolve_response_flags_value(response_flags),
@@ -1365,7 +1366,7 @@ class SyncClient:
     @copy_doc(Client.fetch_variants_beans)
     def fetch_variants_beans(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[VariantBean[SyncHTTPClient]]:
+    ) -> list[VariantBean[SyncHTTPClient]]:
         data = self.http.get_cosmetics_beans(
             language=self._resolve_default_language_value(language),
             response_flags=self._resolve_response_flags_value(response_flags),
@@ -1378,7 +1379,7 @@ class SyncClient:
     @copy_doc(Client.fetch_cosmetics_tracks)
     def fetch_cosmetics_tracks(
         self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
-    ) -> List[CosmeticTrack[SyncHTTPClient]]:
+    ) -> list[CosmeticTrack[SyncHTTPClient]]:
         data = self.http.get_cosmetics_tracks(
             language=self._resolve_default_language_value(language),
             response_flags=self._resolve_response_flags_value(response_flags),
@@ -1455,7 +1456,7 @@ class SyncClient:
         added_since: Optional[datetime.datetime] = ...,
         unseen_for: Optional[int] = ...,
         last_appearance: Optional[datetime.datetime] = ...,
-    ) -> List[CosmeticBr[SyncHTTPClient]]: ...
+    ) -> list[CosmeticBr[SyncHTTPClient]]: ...
 
     @overload
     def search_br_cosmetics(
@@ -1499,7 +1500,7 @@ class SyncClient:
     ) -> CosmeticBr[SyncHTTPClient]: ...
 
     @copy_doc(Client.search_br_cosmetics)
-    def search_br_cosmetics(self, **kwargs: Any) -> Union[CosmeticBr[SyncHTTPClient], List[CosmeticBr[SyncHTTPClient]]]:
+    def search_br_cosmetics(self, **kwargs: Any) -> Union[CosmeticBr[SyncHTTPClient], list[CosmeticBr[SyncHTTPClient]]]:
         multiple = kwargs.pop('multiple')
 
         kwargs['language'] = self._resolve_default_language_value(kwargs.pop('language', MISSING))
@@ -1530,7 +1531,7 @@ class SyncClient:
 
     # BANNERS
     @copy_doc(Client.fetch_banners)
-    def fetch_banners(self, *, language: Optional[GameLanguage] = MISSING) -> List[Banner[SyncHTTPClient]]:
+    def fetch_banners(self, *, language: Optional[GameLanguage] = MISSING) -> list[Banner[SyncHTTPClient]]:
         data = self.http.get_banners(language=self._resolve_default_language_value(language))
         return TransformerListProxy(
             data,
@@ -1538,7 +1539,7 @@ class SyncClient:
         )
 
     @copy_doc(Client.fetch_banner_colors)
-    def fetch_banner_colors(self) -> List[BannerColor[SyncHTTPClient]]:
+    def fetch_banner_colors(self) -> list[BannerColor[SyncHTTPClient]]:
         data = self.http.get_banner_colors()
         return TransformerListProxy(
             data,
@@ -1579,7 +1580,7 @@ class SyncClient:
     # PLAYLISTS
 
     @copy_doc(Client.fetch_playlists)
-    def fetch_playlists(self, /, *, language: Optional[GameLanguage] = MISSING) -> List[Playlist[SyncHTTPClient]]:
+    def fetch_playlists(self, /, *, language: Optional[GameLanguage] = MISSING) -> list[Playlist[SyncHTTPClient]]:
         data = self.http.get_playlists(language=self._resolve_default_language_value(language))
         return TransformerListProxy(
             data,
@@ -1625,7 +1626,7 @@ class SyncClient:
 
     @copy_doc(Client.beta_fetch_new_display_assets)
     @beta_method
-    def beta_fetch_new_display_assets(self) -> List[NewDisplayAsset[SyncHTTPClient]]:
+    def beta_fetch_new_display_assets(self) -> list[NewDisplayAsset[SyncHTTPClient]]:
         data = self.http.beta_get_new_display_assets()
 
         return TransformerListProxy(
@@ -1635,7 +1636,7 @@ class SyncClient:
 
     @copy_doc(Client.beta_fetch_material_instances)
     @beta_method
-    def beta_fetch_material_instances(self) -> List[MaterialInstance[SyncHTTPClient]]:
+    def beta_fetch_material_instances(self) -> list[MaterialInstance[SyncHTTPClient]]:
         data = self.http.beta_get_material_instances()
 
         return TransformerListProxy(

--- a/fortnite_api/cosmetics/br.py
+++ b/fortnite_api/cosmetics/br.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from ..abc import ReconstructAble
 from ..asset import Asset
@@ -33,7 +33,7 @@ from ..http import HTTPClientT
 from ..utils import get_with_fallback, parse_time, simple_repr
 from .common import Cosmetic, CosmeticImages, CosmeticRarityInfo, CosmeticSeriesInfo, CosmeticTypeInfo
 
-__all__: Tuple[str, ...] = (
+__all__: tuple[str, ...] = (
     'CosmeticBrSet',
     'CosmeticBrIntroduction',
     'CosmeticBrVariant',
@@ -43,7 +43,7 @@ __all__: Tuple[str, ...] = (
 
 
 @simple_repr
-class CosmeticBrSet(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class CosmeticBrSet(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticBrSet
 
@@ -66,9 +66,9 @@ class CosmeticBrSet(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The backend value of this set.
     """
 
-    __slots__: Tuple[str, ...] = ('value', 'text', 'backend_value')
+    __slots__: tuple[str, ...] = ('value', 'text', 'backend_value')
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.value: Optional[str] = data.get('value')
@@ -77,7 +77,7 @@ class CosmeticBrSet(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class CosmeticBrIntroduction(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class CosmeticBrIntroduction(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticBrIntroduction
 
@@ -102,9 +102,9 @@ class CosmeticBrIntroduction(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The backend value of this introduction.
     """
 
-    __slots__: Tuple[str, ...] = ('chapter', 'season', 'text', 'backend_value')
+    __slots__: tuple[str, ...] = ('chapter', 'season', 'text', 'backend_value')
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
         self.chapter: int = int(data['chapter'])
         self.season: str = data['season']
@@ -113,7 +113,7 @@ class CosmeticBrIntroduction(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class CosmeticBrVariantOption(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class CosmeticBrVariantOption(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticBrVariantOption
 
@@ -138,9 +138,9 @@ class CosmeticBrVariantOption(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The image of the variant option.
     """
 
-    __slots__: Tuple[str, ...] = ('tag', 'name', 'unlock_requirements', 'image')
+    __slots__: tuple[str, ...] = ('tag', 'name', 'unlock_requirements', 'image')
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.tag: str = data['tag']
@@ -150,7 +150,7 @@ class CosmeticBrVariantOption(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class CosmeticBrVariant(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class CosmeticBrVariant(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticBrVariant
 
@@ -173,21 +173,21 @@ class CosmeticBrVariant(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The options for the variant, if any.
     """
 
-    __slots__: Tuple[str, ...] = ('channel', 'type', 'options')
+    __slots__: tuple[str, ...] = ('channel', 'type', 'options')
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.channel: str = data['channel']
         self.type: Optional[str] = data.get('type')
 
-        self.options: List[CosmeticBrVariantOption[HTTPClientT]] = [
+        self.options: list[CosmeticBrVariantOption[HTTPClientT]] = [
             CosmeticBrVariantOption(data=option, http=http) for option in data['options']
         ]
 
 
 @simple_repr
-class CosmeticBr(Cosmetic[Dict[str, Any], HTTPClientT]):
+class CosmeticBr(Cosmetic[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticBr
 
@@ -263,7 +263,7 @@ class CosmeticBr(Cosmetic[Dict[str, Any], HTTPClientT]):
         .. opt-in:: INCLUDE_SHOP_HISTORY
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         'name',
         'description',
         'exclusive_description',
@@ -292,7 +292,7 @@ class CosmeticBr(Cosmetic[Dict[str, Any], HTTPClientT]):
     def __init__(
         self,
         *,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         http: HTTPClientT,
     ) -> None:
         super().__init__(http=http, data=data)
@@ -323,18 +323,18 @@ class CosmeticBr(Cosmetic[Dict[str, Any], HTTPClientT]):
         images = data.get('images')
         self.images: Optional[CosmeticImages[HTTPClientT]] = images and CosmeticImages(http=http, data=images)
 
-        variants: List[Dict[str, Any]] = get_with_fallback(data, 'variants', list)
-        self.variants: List[CosmeticBrVariant[HTTPClientT]] = [
+        variants: list[dict[str, Any]] = get_with_fallback(data, 'variants', list)
+        self.variants: list[CosmeticBrVariant[HTTPClientT]] = [
             CosmeticBrVariant(data=variant, http=http) for variant in variants
         ]
 
-        built_in_emote_ids: List[str] = get_with_fallback(data, 'builtInEmoteId', list)
-        self.built_in_emote_ids: List[str] = built_in_emote_ids
+        built_in_emote_ids: list[str] = get_with_fallback(data, 'builtInEmoteId', list)
+        self.built_in_emote_ids: list[str] = built_in_emote_ids
 
-        self.search_tags: List[str] = get_with_fallback(data, 'searchTags', list)
+        self.search_tags: list[str] = get_with_fallback(data, 'searchTags', list)
 
-        self.gameplay_tags: List[str] = get_with_fallback(data, 'gameplayTags', list)
-        self.meta_tags: List[str] = get_with_fallback(data, 'metaTags', list)
+        self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplayTags', list)
+        self.meta_tags: list[str] = get_with_fallback(data, 'metaTags', list)
 
         self.showcase_video_id: Optional[str] = data.get('showcaseVideo')
         self.dynamic_pak_id: Optional[str] = data.get('dynamicPakId')
@@ -343,7 +343,7 @@ class CosmeticBr(Cosmetic[Dict[str, Any], HTTPClientT]):
         self.definition_path: Optional[str] = data.get('definitionPath')
         self.path: Optional[str] = data.get('path')
 
-        self.shop_history: List[datetime.datetime] = [
+        self.shop_history: list[datetime.datetime] = [
             parse_time(time) for time in get_with_fallback(data, 'shopHistory', list)
         ]
 

--- a/fortnite_api/cosmetics/car.py
+++ b/fortnite_api/cosmetics/car.py
@@ -25,17 +25,17 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from ..http import HTTPClientT
 from ..utils import get_with_fallback, parse_time, simple_repr
 from .common import Cosmetic, CosmeticImages, CosmeticRarityInfo, CosmeticSeriesInfo, CosmeticTypeInfo
 
-__all__: Tuple[str, ...] = ('CosmeticCar',)
+__all__: tuple[str, ...] = ('CosmeticCar',)
 
 
 @simple_repr
-class CosmeticCar(Cosmetic[Dict[str, Any], HTTPClientT]):
+class CosmeticCar(Cosmetic[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticCar
 
@@ -81,7 +81,7 @@ class CosmeticCar(Cosmetic[Dict[str, Any], HTTPClientT]):
         .. opt-in:: INCLUDE_SHOP_HISTORY
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         'vehicle_id',
         'name',
         'description',
@@ -95,7 +95,7 @@ class CosmeticCar(Cosmetic[Dict[str, Any], HTTPClientT]):
         'shop_history',
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.vehicle_id: str = data['vehicleId']
@@ -116,11 +116,11 @@ class CosmeticCar(Cosmetic[Dict[str, Any], HTTPClientT]):
             data=_series, http=self._http
         )
 
-        self.gameplay_tags: List[str] = get_with_fallback(data, 'gameplayTags', list)
+        self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplayTags', list)
         self.path: Optional[str] = data.get('path')
         self.showcase_video_id: Optional[str] = data.get('showcaseVideo')
 
-        self.shop_history: List[datetime.datetime] = [
+        self.shop_history: list[datetime.datetime] = [
             parse_time(time) for time in get_with_fallback(data, 'shopHistory', list)
         ]
 

--- a/fortnite_api/cosmetics/common.py
+++ b/fortnite_api/cosmetics/common.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 from ..abc import DictT, Hashable, ReconstructAble
 from ..asset import Asset
@@ -36,7 +36,7 @@ from ..utils import get_with_fallback, parse_time, simple_repr
 
 CosmeticT = TypeVar("CosmeticT", bound="Cosmetic[Any, Any]")
 
-__all__: Tuple[str, ...] = (
+__all__: tuple[str, ...] = (
     "Cosmetic",
     "CosmeticTypeInfo",
     "CosmeticRarityInfo",
@@ -71,7 +71,7 @@ class Cosmetic(Generic[DictT, HTTPClientT], Hashable, ReconstructAble[DictT, HTT
         When the cosmetic was added.
     """
 
-    __slots__: Tuple[str, ...] = ("id", "added")
+    __slots__: tuple[str, ...] = ("id", "added")
 
     def __init__(
         self,
@@ -86,7 +86,7 @@ class Cosmetic(Generic[DictT, HTTPClientT], Hashable, ReconstructAble[DictT, HTT
 
 
 @simple_repr
-class CosmeticTypeInfo(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class CosmeticTypeInfo(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticTypeInfo
 
@@ -115,14 +115,14 @@ class CosmeticTypeInfo(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The internal marker of the cosmetic type.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "value",
         "raw_value",
         "display_value",
         "backend_value",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.value: CosmeticType = CosmeticType(data["value"])
@@ -133,7 +133,7 @@ class CosmeticTypeInfo(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class CosmeticRarityInfo(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class CosmeticRarityInfo(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticRarityInfo
 
@@ -157,9 +157,9 @@ class CosmeticRarityInfo(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The internal marker of the cosmetic rarity.
     """
 
-    __slots__: Tuple[str, ...] = ("value", "display_value", "backend_value")
+    __slots__: tuple[str, ...] = ("value", "display_value", "backend_value")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.value: CosmeticRarity = CosmeticRarity(data["value"])
@@ -168,7 +168,7 @@ class CosmeticRarityInfo(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class CosmeticSeriesInfo(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class CosmeticSeriesInfo(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticSeriesInfo
 
@@ -193,12 +193,12 @@ class CosmeticSeriesInfo(ReconstructAble[Dict[str, Any], HTTPClientT]):
         A list of colors that are associated with the cosmetic series.
     """
 
-    __slots__: Tuple[str, ...] = ("value", "backend_value", "image", "colors")
+    __slots__: tuple[str, ...] = ("value", "backend_value", "image", "colors")
 
     def __init__(
         self,
         *,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         http: HTTPClientT,
     ) -> None:
         super().__init__(data=data, http=http)
@@ -209,7 +209,7 @@ class CosmeticSeriesInfo(ReconstructAble[Dict[str, Any], HTTPClientT]):
         image = data.get("image")
         self.image: Optional[Asset[HTTPClientT]] = image and Asset(http=http, url=image)
 
-        self.colors: List[str] = get_with_fallback(data, "colors", list)
+        self.colors: list[str] = get_with_fallback(data, "colors", list)
 
 
 @simple_repr
@@ -247,7 +247,7 @@ class CosmeticImages(Images[HTTPClientT]):
         The wide image of the cosmetic. Typically available off of :class:`fortnite_api.VariantLego` objects.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "featured",
         "lego",
         "bean",
@@ -261,7 +261,7 @@ class CosmeticImages(Images[HTTPClientT]):
     def __init__(
         self,
         *,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         http: HTTPClientT,
     ) -> None:
         super().__init__(data=data, http=http)
@@ -284,7 +284,7 @@ class CosmeticImages(Images[HTTPClientT]):
         wide = data.get("wide")
         self.wide: Optional[Asset[HTTPClientT]] = wide and Asset(http=http, url=wide)
 
-        self._other: Dict[str, str] = get_with_fallback(data, "other", dict)
+        self._other: dict[str, str] = get_with_fallback(data, "other", dict)
         self._http: HTTPClientT = http
 
     @property

--- a/fortnite_api/cosmetics/instrument.py
+++ b/fortnite_api/cosmetics/instrument.py
@@ -25,17 +25,17 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from ..http import HTTPClientT
 from ..utils import get_with_fallback, parse_time, simple_repr
 from .common import Cosmetic, CosmeticImages, CosmeticRarityInfo, CosmeticSeriesInfo, CosmeticTypeInfo
 
-__all__: Tuple[str, ...] = ('CosmeticInstrument',)
+__all__: tuple[str, ...] = ('CosmeticInstrument',)
 
 
 @simple_repr
-class CosmeticInstrument(Cosmetic[Dict[str, Any], HTTPClientT]):
+class CosmeticInstrument(Cosmetic[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticInstrument
 
@@ -79,7 +79,7 @@ class CosmeticInstrument(Cosmetic[Dict[str, Any], HTTPClientT]):
         .. opt-in:: INCLUDE_SHOP_HISTORY
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         'name',
         'description',
         'type',
@@ -92,7 +92,7 @@ class CosmeticInstrument(Cosmetic[Dict[str, Any], HTTPClientT]):
         'shop_history',
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.name: str = data['name']
@@ -112,11 +112,11 @@ class CosmeticInstrument(Cosmetic[Dict[str, Any], HTTPClientT]):
             data=_series, http=self._http
         )
 
-        self.gameplay_tags: List[str] = get_with_fallback(data, 'gameplayTags', list)
+        self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplayTags', list)
         self.path: Optional[str] = data.get('path')
         self.showcase_video_id: Optional[str] = data.get('showcaseVideo')
 
-        self.shop_history: List[datetime.datetime] = [
+        self.shop_history: list[datetime.datetime] = [
             parse_time(time) for time in get_with_fallback(data, 'shopHistory', list)
         ]
 

--- a/fortnite_api/cosmetics/lego_kit.py
+++ b/fortnite_api/cosmetics/lego_kit.py
@@ -24,17 +24,17 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from ..http import HTTPClientT
 from ..utils import get_with_fallback, parse_time, simple_repr
 from .common import Cosmetic, CosmeticImages, CosmeticSeriesInfo, CosmeticTypeInfo
 
-__all__: Tuple[str, ...] = ('CosmeticLegoKit',)
+__all__: tuple[str, ...] = ('CosmeticLegoKit',)
 
 
 @simple_repr
-class CosmeticLegoKit(Cosmetic[Dict[str, Any], HTTPClientT]):
+class CosmeticLegoKit(Cosmetic[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticLegoKit
 
@@ -70,9 +70,9 @@ class CosmeticLegoKit(Cosmetic[Dict[str, Any], HTTPClientT]):
         .. opt-in:: INCLUDE_SHOP_HISTORY
     """
 
-    __slots__: Tuple[str, ...] = ('name', 'type', 'gameplay_tags', 'images', 'path', 'shop_history')
+    __slots__: tuple[str, ...] = ('name', 'type', 'gameplay_tags', 'images', 'path', 'shop_history')
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.name: str = data['name']
@@ -83,7 +83,7 @@ class CosmeticLegoKit(Cosmetic[Dict[str, Any], HTTPClientT]):
         _series = data.get('series')
         self.series: Optional[CosmeticSeriesInfo[HTTPClientT]] = _series and CosmeticSeriesInfo(data=_series, http=http)
 
-        self.gameplay_tags: List[str] = get_with_fallback(data, 'gameplayTags', list)
+        self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplayTags', list)
 
         _images = data.get('images')
         self.images: Optional[CosmeticImages[HTTPClientT]] = _images and CosmeticImages(data=_images, http=http)

--- a/fortnite_api/cosmetics/track.py
+++ b/fortnite_api/cosmetics/track.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from ..abc import ReconstructAble
 from ..asset import Asset
@@ -33,11 +33,11 @@ from ..http import HTTPClientT
 from ..utils import get_with_fallback, parse_time, simple_repr
 from .common import Cosmetic
 
-__all__: Tuple[str, ...] = ('CosmeticTrackDifficulty', 'CosmeticTrack')
+__all__: tuple[str, ...] = ('CosmeticTrackDifficulty', 'CosmeticTrack')
 
 
 @simple_repr
-class CosmeticTrackDifficulty(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class CosmeticTrackDifficulty(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticTrackDifficulty
 
@@ -66,9 +66,9 @@ class CosmeticTrackDifficulty(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The plastic drums difficulty of the track.
     """
 
-    __slots__: Tuple[str, ...] = ('vocals', 'guitar', 'bass', 'plastic_bass', 'drums', 'plastic_drums')
+    __slots__: tuple[str, ...] = ('vocals', 'guitar', 'bass', 'plastic_bass', 'drums', 'plastic_drums')
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.vocals: int = data['vocals']
@@ -80,7 +80,7 @@ class CosmeticTrackDifficulty(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class CosmeticTrack(Cosmetic[Dict[str, Any], HTTPClientT]):
+class CosmeticTrack(Cosmetic[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CosmeticTrack
 
@@ -126,7 +126,7 @@ class CosmeticTrack(Cosmetic[Dict[str, Any], HTTPClientT]):
         .. opt-in:: INCLUDE_SHOP_HISTORY
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         'dev_name',
         'title',
         'artist',
@@ -141,7 +141,7 @@ class CosmeticTrack(Cosmetic[Dict[str, Any], HTTPClientT]):
         'shop_history',
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.dev_name: str = data['devName']
@@ -153,10 +153,10 @@ class CosmeticTrack(Cosmetic[Dict[str, Any], HTTPClientT]):
         self.duration: int = data['duration']
 
         self.difficulty: CosmeticTrackDifficulty[HTTPClientT] = CosmeticTrackDifficulty(data=data['difficulty'], http=http)
-        self.gameplay_tags: List[str] = get_with_fallback(data, 'gameplayTags', list)
-        self.genres: List[str] = get_with_fallback(data, 'genres', list)
+        self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplayTags', list)
+        self.genres: list[str] = get_with_fallback(data, 'genres', list)
         self.album_art: Asset[HTTPClientT] = Asset(http=http, url=data['albumArt'])
 
-        self.shop_history: List[datetime.datetime] = [
+        self.shop_history: list[datetime.datetime] = [
             parse_time(time) for time in get_with_fallback(data, 'shopHistory', list)
         ]

--- a/fortnite_api/cosmetics/variants/bean.py
+++ b/fortnite_api/cosmetics/variants/bean.py
@@ -24,7 +24,8 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Coroutine, Dict, List, Optional, Tuple, Union, overload
+from collections.abc import Coroutine
+from typing import TYPE_CHECKING, Any, Optional, Union, overload
 
 from ...enums import CustomGender, GameLanguage
 from ...http import HTTPClientT
@@ -35,10 +36,10 @@ from ..common import Cosmetic, CosmeticImages
 if TYPE_CHECKING:
     from ...http import HTTPClient, SyncHTTPClient
 
-__all__: Tuple[str, ...] = ('VariantBean',)
+__all__: tuple[str, ...] = ('VariantBean',)
 
 
-class VariantBean(Cosmetic[Dict[str, Any], HTTPClientT]):
+class VariantBean(Cosmetic[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.VariantBean
 
@@ -70,13 +71,13 @@ class VariantBean(Cosmetic[Dict[str, Any], HTTPClientT]):
         .. opt-in:: INCLUDE_PATHS
     """
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.cosmetic_id: Optional[str] = data.get('cosmetic_id')
         self.name: str = data['name']
         self.gender: CustomGender = CustomGender(data['gender'])
-        self.gameplay_tags: List[str] = get_with_fallback(data, 'gameplay_tags', list)
+        self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplay_tags', list)
 
         _images = data.get('images')
         self.images: Optional[CosmeticImages[HTTPClientT]] = _images and CosmeticImages(data=_images, http=http)

--- a/fortnite_api/cosmetics/variants/lego.py
+++ b/fortnite_api/cosmetics/variants/lego.py
@@ -24,7 +24,8 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Coroutine, Dict, List, Optional, Tuple, Union, overload
+from collections.abc import Coroutine
+from typing import TYPE_CHECKING, Any, Optional, Union, overload
 
 from ...enums import GameLanguage
 from ...http import HTTPClientT
@@ -35,11 +36,11 @@ from ..common import Cosmetic, CosmeticImages
 if TYPE_CHECKING:
     from ...http import HTTPClient, SyncHTTPClient
 
-__all__: Tuple[str, ...] = ('VariantLego',)
+__all__: tuple[str, ...] = ('VariantLego',)
 
 
 @simple_repr
-class VariantLego(Cosmetic[Dict[str, Any], HTTPClientT]):
+class VariantLego(Cosmetic[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.VariantLego
 
@@ -68,13 +69,13 @@ class VariantLego(Cosmetic[Dict[str, Any], HTTPClientT]):
         .. opt-in:: INCLUDE_PATHS
     """
 
-    __slots__: Tuple[str, ...] = ('cosmetic_id', 'sound_library_tags', 'images', 'path')
+    __slots__: tuple[str, ...] = ('cosmetic_id', 'sound_library_tags', 'images', 'path')
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.cosmetic_id: str = data['cosmeticId']
-        self.sound_library_tags: List[str] = get_with_fallback(data, 'soundLibraryTags', list)
+        self.sound_library_tags: list[str] = get_with_fallback(data, 'soundLibraryTags', list)
 
         _images = data.get('images')
         self.images: Optional[CosmeticImages[HTTPClientT]] = _images and CosmeticImages(data=_images, http=http)

--- a/fortnite_api/creator_code.py
+++ b/fortnite_api/creator_code.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from .abc import ReconstructAble
 from .account import Account
@@ -32,11 +32,11 @@ from .enums import CreatorCodeStatus
 from .http import HTTPClientT
 from .utils import simple_repr
 
-__all__: Tuple[str, ...] = ("CreatorCode",)
+__all__: tuple[str, ...] = ("CreatorCode",)
 
 
 @simple_repr
-class CreatorCode(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class CreatorCode(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.CreatorCode
 
@@ -67,9 +67,9 @@ class CreatorCode(ReconstructAble[Dict[str, Any], HTTPClientT]):
             From internal testing, this seems to be always ``False``.
     """
 
-    __slots__: Tuple[str, ...] = ("code", "account", "verified", "status")
+    __slots__: tuple[str, ...] = ("code", "account", "verified", "status")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.code: str = data["code"]

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -25,11 +25,10 @@ SOFTWARE.
 from __future__ import annotations
 
 import enum
-from typing import Tuple, Type
 
 from typing_extensions import Self
 
-__all__: Tuple[str, ...] = (
+__all__: tuple[str, ...] = (
     'KeyFormat',
     'GameLanguage',
     'MatchMethod',
@@ -385,7 +384,7 @@ class CosmeticCompatibleMode(enum.Enum):
     ALL = 'max'
 
     @classmethod
-    def _from_str(cls: Type[Self], string: str) -> Self:
+    def _from_str(cls: type[Self], string: str) -> Self:
         # The Epic Games API uses both "CosmeticCompatibleMode" and "CosmeticCompatibleModeLegacy" enums
         # with the same values, so we need to handle both.
         # To easily handle this, we'll remove the "ECosmeticCompatibleMode::" or "ECosmeticCompatibleModeLegacy::" prefix.
@@ -450,7 +449,7 @@ class ProductTag(enum.Enum):
     ALL = 'max'
 
     @classmethod
-    def _from_str(cls: Type[Self], string: str) -> Self:
+    def _from_str(cls: type[Self], string: str) -> Self:
         # The Epic Games API "Product" enums contains both lower case and capitalized values, so we need to handle both.
         # To easily handle this, we'll remove the "Product." prefix and convert it to lowercase.
         trimmed = string.split('.')[-1]

--- a/fortnite_api/errors.py
+++ b/fortnite_api/errors.py
@@ -24,13 +24,13 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 if TYPE_CHECKING:
     import aiohttp
     import requests
 
-__all__: Tuple[str, ...] = (
+__all__: tuple[str, ...] = (
     "FortniteAPIException",
     "HTTPException",
     "NotFound",

--- a/fortnite_api/flags.py
+++ b/fortnite_api/flags.py
@@ -25,11 +25,10 @@ SOFTWARE.
 from __future__ import annotations
 
 import enum
-from typing import Tuple, Type
 
 from typing_extensions import Self
 
-__all__: Tuple[str, ...] = ('ResponseFlags',)
+__all__: tuple[str, ...] = ('ResponseFlags',)
 
 
 class ResponseFlags(enum.IntFlag):
@@ -63,7 +62,7 @@ class ResponseFlags(enum.IntFlag):
     INCLUDE_SHOP_HISTORY = 1 << 2
 
     @classmethod
-    def all(cls: Type[Self]) -> Self:
+    def all(cls: type[Self]) -> Self:
         """:class:`ResponseFlags`: Returns a flag that includes all flags."""
         self = cls.INCLUDE_NOTHING
         for item in cls:

--- a/fortnite_api/http.py
+++ b/fortnite_api/http.py
@@ -29,7 +29,8 @@ import asyncio
 import logging
 import sys
 import time
-from typing import Any, ClassVar, Coroutine, Dict, Literal, Optional, Union
+from collections.abc import Coroutine
+from typing import Any, ClassVar, Literal, Optional, Union
 from urllib.parse import quote as _uriquote
 
 import aiohttp
@@ -73,7 +74,7 @@ class Route:
     def __init__(self, method: str, path: str, **params: Any) -> None:
         self.method: str = method
         self.path: str = path
-        self.params: Optional[Dict[str, Any]] = params
+        self.params: Optional[dict[str, Any]] = params
 
         url = self.BASE_URL + path
         if params:
@@ -96,7 +97,7 @@ class HTTPMixin(abc.ABC):
             __version__, sys.version_info
         )
 
-        self.headers: Dict[str, Any] = {'User-Agent': self.user_agent}
+        self.headers: dict[str, Any] = {'User-Agent': self.user_agent}
         if self.token is not None:
             self.headers['Authorization'] = self.token
 
@@ -105,7 +106,7 @@ class HTTPMixin(abc.ABC):
 
     def get_cosmetics_br(self, language: Optional[str] = None, response_flags: Optional[int] = None):
         r: Route = Route('GET', '/v2/cosmetics/br')
-        params: Dict[str, Union[str, int]] = {}
+        params: dict[str, Union[str, int]] = {}
 
         if language:
             params['language'] = language
@@ -117,7 +118,7 @@ class HTTPMixin(abc.ABC):
 
     def get_cosmetics_cars(self, language: Optional[str] = None, response_flags: Optional[int] = None):
         r: Route = Route('GET', '/v2/cosmetics/cars')
-        params: Dict[str, Union[str, int]] = {}
+        params: dict[str, Union[str, int]] = {}
 
         if language:
             params['language'] = language
@@ -129,7 +130,7 @@ class HTTPMixin(abc.ABC):
 
     def get_cosmetics_instruments(self, language: Optional[str] = None, response_flags: Optional[int] = None):
         r: Route = Route('GET', '/v2/cosmetics/instruments')
-        params: Dict[str, Union[str, int]] = {}
+        params: dict[str, Union[str, int]] = {}
 
         if language:
             params['language'] = language
@@ -141,7 +142,7 @@ class HTTPMixin(abc.ABC):
 
     def get_cosmetics_lego_kits(self, language: Optional[str] = None, response_flags: Optional[int] = None):
         r: Route = Route('GET', '/v2/cosmetics/lego/kits')
-        params: Dict[str, Union[str, int]] = {}
+        params: dict[str, Union[str, int]] = {}
 
         if language:
             params['language'] = language
@@ -153,7 +154,7 @@ class HTTPMixin(abc.ABC):
 
     def get_cosmetics_tracks(self, language: Optional[str] = None, response_flags: Optional[int] = None):
         r: Route = Route('GET', '/v2/cosmetics/tracks')
-        params: Dict[str, Union[str, int]] = {}
+        params: dict[str, Union[str, int]] = {}
 
         if language:
             params['language'] = language
@@ -165,7 +166,7 @@ class HTTPMixin(abc.ABC):
 
     def get_cosmetics_lego(self, language: Optional[str] = None, response_flags: Optional[int] = None):
         r: Route = Route('GET', '/v2/cosmetics/lego')
-        params: Dict[str, Union[str, int]] = {}
+        params: dict[str, Union[str, int]] = {}
 
         if language:
             params['language'] = language
@@ -177,7 +178,7 @@ class HTTPMixin(abc.ABC):
 
     def get_cosmetics_beans(self, language: Optional[str] = None, response_flags: Optional[int] = None):
         r: Route = Route('GET', '/v2/cosmetics/beans')
-        params: Dict[str, Union[str, int]] = {}
+        params: dict[str, Union[str, int]] = {}
 
         if language:
             params['language'] = language
@@ -189,7 +190,7 @@ class HTTPMixin(abc.ABC):
 
     def get_cosmetics_new(self, language: Optional[str] = None, response_flags: Optional[int] = None):
         r: Route = Route('GET', '/v2/cosmetics/new')
-        params: Dict[str, Union[str, int]] = {}
+        params: dict[str, Union[str, int]] = {}
 
         if language:
             params['language'] = language
@@ -201,7 +202,7 @@ class HTTPMixin(abc.ABC):
 
     def get_cosmetic_br(self, id: str, language: Optional[str] = None, response_flags: Optional[int] = None):
         r: Route = Route('GET', '/v2/cosmetics/br/{id}', id=id)
-        params: Dict[str, Union[str, int]] = {}
+        params: dict[str, Union[str, int]] = {}
 
         if language:
             params['language'] = language
@@ -213,7 +214,7 @@ class HTTPMixin(abc.ABC):
 
     def get_cosmetics_all(self, language: Optional[str] = None, response_flags: Optional[int] = None):
         r: Route = Route('GET', '/v2/cosmetics')
-        params: Dict[str, Union[str, int]] = {}
+        params: dict[str, Union[str, int]] = {}
 
         if language:
             params['language'] = language
@@ -225,12 +226,12 @@ class HTTPMixin(abc.ABC):
 
     def get_aes(self, key_format: str):
         r: Route = Route('GET', '/v2/aes')
-        params: Dict[str, str] = {'keyFormat': key_format}
+        params: dict[str, str] = {'keyFormat': key_format}
         return self.request(r, params=params)
 
     def get_banners(self, language: Optional[str] = None):
         r: Route = Route('GET', '/v1/banners')
-        params: Dict[str, str] = {}
+        params: dict[str, str] = {}
 
         if language:
             params['language'] = language
@@ -252,12 +253,12 @@ class HTTPMixin(abc.ABC):
 
     def get_creator_code(self, name: str):
         r: Route = Route('GET', '/v2/creatorcode', name=name)
-        params: Dict[str, str] = {'name': name}
+        params: dict[str, str] = {'name': name}
         return self.request(r, params=params)
 
     def get_map(self, language: Optional[str] = None):
         r: Route = Route('GET', '/v1/map')
-        params: Dict[str, str] = {}
+        params: dict[str, str] = {}
 
         if language:
             params['language'] = language
@@ -266,7 +267,7 @@ class HTTPMixin(abc.ABC):
 
     def get_news(self, language: Optional[str] = None):
         r: Route = Route('GET', '/v2/news')
-        params: Dict[str, str] = {}
+        params: dict[str, str] = {}
 
         if language:
             params['language'] = language
@@ -275,7 +276,7 @@ class HTTPMixin(abc.ABC):
 
     def get_news_br(self, language: Optional[str] = None):
         r: Route = Route('GET', '/v2/news/br')
-        params: Dict[str, str] = {}
+        params: dict[str, str] = {}
 
         if language:
             params['language'] = language
@@ -284,7 +285,7 @@ class HTTPMixin(abc.ABC):
 
     def get_news_stw(self, language: Optional[str] = None):
         r: Route = Route('GET', '/v2/news/stw')
-        params: Dict[str, str] = {}
+        params: dict[str, str] = {}
 
         if language:
             params['language'] = language
@@ -293,7 +294,7 @@ class HTTPMixin(abc.ABC):
 
     def get_playlists(self, language: Optional[str] = None):
         r: Route = Route('GET', '/v1/playlists')
-        params: Dict[str, str] = {}
+        params: dict[str, str] = {}
 
         if language:
             params['language'] = language
@@ -302,7 +303,7 @@ class HTTPMixin(abc.ABC):
 
     def get_playlist(self, id: str, language: Optional[str] = None):
         r: Route = Route('GET', '/v1/playlists/{id}', id=id)
-        params: Dict[str, str] = {}
+        params: dict[str, str] = {}
 
         if language:
             params['language'] = language
@@ -311,7 +312,7 @@ class HTTPMixin(abc.ABC):
 
     def get_shop(self, language: Optional[str] = None, response_flags: Optional[int] = None):
         r: Route = Route('GET', '/v2/shop')
-        params: Dict[str, Union[str, int]] = {}
+        params: dict[str, Union[str, int]] = {}
 
         if language:
             params['language'] = language
@@ -329,7 +330,7 @@ class HTTPMixin(abc.ABC):
         image: Literal['all', 'keyboardMouse', 'gamepad', 'touch', 'none'] = 'none',
     ):
         r: Route = Route('GET', '/v2/stats/br/v2', name=name)
-        params: Dict[str, str] = {'name': name, 'accountType': account_type, 'timeWindow': time_window, 'image': image}
+        params: dict[str, str] = {'name': name, 'accountType': account_type, 'timeWindow': time_window, 'image': image}
 
         return self.request(r, params=params)
 
@@ -340,7 +341,7 @@ class HTTPMixin(abc.ABC):
         image: Literal['all', 'keyboardMouse', 'gamepad', 'touch', 'none'] = 'none',
     ):
         r: Route = Route('GET', '/v2/stats/br/v2/{account_id}', account_id=account_id)
-        params: Dict[str, str] = {'timeWindow': time_window, 'image': image}
+        params: dict[str, str] = {'timeWindow': time_window, 'image': image}
 
         return self.request(r, params=params)
 
@@ -362,7 +363,7 @@ class HTTPClient(HTTPMixin):
         if self.session is not None:
             await self.session.close()
 
-    async def _parse_async_response(self, response: aiohttp.ClientResponse) -> Union[Dict[str, Any], str, bytes]:
+    async def _parse_async_response(self, response: aiohttp.ClientResponse) -> Union[dict[str, Any], str, bytes]:
         try:
             text = await response.text()
         except UnicodeDecodeError:
@@ -451,7 +452,7 @@ class SyncHTTPClient(HTTPMixin):
         if self.session is not None:
             self.session.close()
 
-    def _parse_sync_response(self, response: requests.Response) -> Union[Dict[str, Any], str, bytes]:
+    def _parse_sync_response(self, response: requests.Response) -> Union[dict[str, Any], str, bytes]:
         content_type = response.headers.get('Content-Type')
         if content_type and content_type.startswith('image/'):
             return response.content

--- a/fortnite_api/images.py
+++ b/fortnite_api/images.py
@@ -24,18 +24,18 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 from .abc import ReconstructAble
 from .asset import Asset
 from .http import HTTPClientT
 from .utils import simple_repr
 
-__all__: Tuple[str, ...] = ('Images',)
+__all__: tuple[str, ...] = ('Images',)
 
 
 @simple_repr
-class Images(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class Images(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.Images
 
@@ -58,9 +58,9 @@ class Images(ReconstructAble[Dict[str, Any], HTTPClientT]):
         An icon asset. Typically, this is the main image of the object.
     """
 
-    __slots__: Tuple[str, ...] = ('small_icon', 'icon')
+    __slots__: tuple[str, ...] = ('small_icon', 'icon')
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         small_icon = data.get('smallIcon')

--- a/fortnite_api/map.py
+++ b/fortnite_api/map.py
@@ -24,7 +24,8 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Generator, List, Optional, Tuple
+from collections.abc import Generator
+from typing import Any, Optional
 
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
@@ -32,11 +33,11 @@ from .http import HTTPClientT
 from .proxies import TransformerListProxy
 from .utils import simple_repr
 
-__all__: Tuple[str, ...] = ("Map", "MapImages", "POI", "POILocation")
+__all__: tuple[str, ...] = ("Map", "MapImages", "POI", "POILocation")
 
 
 @simple_repr
-class MapImages(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class MapImages(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.MapImages
 
@@ -57,9 +58,9 @@ class MapImages(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The asset pointing to an image of the map that contains the POI names.
     """
 
-    __slots__: Tuple[str, ...] = ("blank", "pois")
+    __slots__: tuple[str, ...] = ("blank", "pois")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.blank: Asset[HTTPClientT] = Asset(http=http, url=data["blank"])
@@ -67,7 +68,7 @@ class MapImages(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class Map(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class Map(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.Map
 
@@ -97,21 +98,21 @@ class Map(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The list of POIs in the map.
     """
 
-    __slots__: Tuple[str, ...] = ("images", "pois")
+    __slots__: tuple[str, ...] = ("images", "pois")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.images: MapImages[HTTPClientT] = MapImages(data=data["images"], http=http)
 
-        self.pois: List[POI[HTTPClientT]] = TransformerListProxy(
+        self.pois: list[POI[HTTPClientT]] = TransformerListProxy(
             data["pois"],
             transform_data=lambda poi: POI(data=poi, http=http),
         )
 
 
 @simple_repr
-class POI(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
+class POI(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.POI
 
@@ -149,9 +150,9 @@ class POI(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         The location of the POI.
     """
 
-    __slots__: Tuple[str, ...] = ("id", "name", "location")
+    __slots__: tuple[str, ...] = ("id", "name", "location")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.id: str = data["id"]
@@ -160,7 +161,7 @@ class POI(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class POILocation(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class POILocation(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.POILocation
 
@@ -197,9 +198,9 @@ class POILocation(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The z coordinate.
     """
 
-    __slots__: Tuple[str, ...] = ("x", "y", "z")
+    __slots__: tuple[str, ...] = ("x", "y", "z")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.x: float = data["x"]

--- a/fortnite_api/new.py
+++ b/fortnite_api/new.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Dict, Generic, List, Optional, Tuple, Type
+from typing import Any, Generic, Optional
 
 from .abc import ReconstructAble
 from .cosmetics import (
@@ -43,7 +43,7 @@ from .http import HTTPClientT
 from .proxies import TransformerListProxy
 from .utils import get_with_fallback, parse_time
 
-__all__: Tuple[str, ...] = ("NewCosmetic", "NewCosmetics")
+__all__: tuple[str, ...] = ("NewCosmetic", "NewCosmetics")
 
 
 class NewCosmetic(Generic[CosmeticT]):
@@ -92,15 +92,15 @@ class NewCosmetic(Generic[CosmeticT]):
         type: CosmeticCategory,
         hash: Optional[str] = None,
         last_addition: Optional[datetime.datetime] = None,
-        items: List[CosmeticT],
+        items: list[CosmeticT],
     ) -> None:
         self.type: CosmeticCategory = type
         self.hash: Optional[str] = hash
         self.last_addition: Optional[datetime.datetime] = last_addition
-        self.items: List[CosmeticT] = items
+        self.items: list[CosmeticT] = items
 
 
-class NewCosmetics(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class NewCosmetics(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.NewCosmetics
 
@@ -146,7 +146,7 @@ class NewCosmetics(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The new bean cosmetic variants.
     """
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.build: str = data["build"]
@@ -206,9 +206,9 @@ class NewCosmetics(ReconstructAble[Dict[str, Any], HTTPClientT]):
         *,
         cosmetic_type: CosmeticCategory,
         internal_key: str,
-        cosmetic_class: Type[CosmeticT],
+        cosmetic_class: type[CosmeticT],
     ) -> NewCosmetic[CosmeticT]:
-        cosmetic_items: List[Dict[str, Any]] = get_with_fallback(self._items, internal_key, list)
+        cosmetic_items: list[dict[str, Any]] = get_with_fallback(self._items, internal_key, list)
 
         last_addition_str = self._last_additions[internal_key]
         last_addition: Optional[datetime.datetime] = last_addition_str and parse_time(last_addition_str)

--- a/fortnite_api/new_display_asset.py
+++ b/fortnite_api/new_display_asset.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
@@ -32,7 +32,7 @@ from .enums import CosmeticCompatibleMode, ProductTag
 from .http import HTTPClientT
 from .utils import get_with_fallback
 
-__all__: Tuple[str, ...] = (
+__all__: tuple[str, ...] = (
     "RenderImage",
     "MaterialInstanceImages",
     "MaterialInstanceColors",
@@ -41,7 +41,7 @@ __all__: Tuple[str, ...] = (
 )
 
 
-class RenderImage(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class RenderImage(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.RenderImage
 
@@ -63,9 +63,9 @@ class RenderImage(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The image of the render image.
     """
 
-    __slots__: Tuple[str, ...] = ("product_tag", "file_name", "image")
+    __slots__: tuple[str, ...] = ("product_tag", "file_name", "image")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.product_tag: ProductTag = ProductTag._from_str(data["productTag"])
@@ -73,7 +73,7 @@ class RenderImage(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.image: Asset[HTTPClientT] = Asset(url=data["image"], http=http)
 
 
-class MaterialInstanceImages(Dict[str, Asset[HTTPClientT]]):
+class MaterialInstanceImages(dict[str, Asset[HTTPClientT]]):
     """
     .. attributetable:: fortnite_api.MaterialInstanceImages
 
@@ -98,9 +98,9 @@ class MaterialInstanceImages(Dict[str, Asset[HTTPClientT]]):
         for the Material instance.
     """
 
-    __slots__: Tuple[str, ...] = ("offer_image", "background")
+    __slots__: tuple[str, ...] = ("offer_image", "background")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         _offer_image = data.get("OfferImage")
         self.offer_image: Optional[Asset[HTTPClientT]] = _offer_image and Asset(url=_offer_image, http=http)
 
@@ -111,7 +111,7 @@ class MaterialInstanceImages(Dict[str, Asset[HTTPClientT]]):
         super().__init__({key: Asset(url=value, http=http) for key, value in data.items()})
 
 
-class MaterialInstanceColors(Dict[str, str]):
+class MaterialInstanceColors(dict[str, str]):
     """
     .. attributetable:: fortnite_api.MaterialInstanceColors
 
@@ -132,20 +132,20 @@ class MaterialInstanceColors(Dict[str, str]):
         The fall off color of the Material instance, if any.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "background_color_a",
         "background_color_b",
         "fall_off_color",
     )
 
-    def __init__(self, *, data: Dict[str, Any]) -> None:
+    def __init__(self, *, data: dict[str, Any]) -> None:
         self.background_color_a: Optional[str] = data.get("Background_Color_A")
         self.background_color_b: Optional[str] = data.get("Background_Color_B")
         self.fall_off_color: Optional[str] = data.get("FallOff_Color")
         super().__init__(data)
 
 
-class MaterialInstance(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
+class MaterialInstance(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.MaterialInstance
 
@@ -188,7 +188,7 @@ class MaterialInstance(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
             This is always an empty dict, as there are no flags used at this time.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "id",
         "primary_mode",
         "product_tag",
@@ -198,7 +198,7 @@ class MaterialInstance(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         "flags",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.id: str = data["id"]
@@ -209,12 +209,12 @@ class MaterialInstance(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
 
         _colors = data.get("colors")
         self.colors: Optional[MaterialInstanceColors] = _colors and MaterialInstanceColors(data=_colors)
-        self.scalings: Dict[str, Any] = get_with_fallback(data, "scalings", dict)
+        self.scalings: dict[str, Any] = get_with_fallback(data, "scalings", dict)
 
-        self.flags: Dict[str, Any] = get_with_fallback(data, "flags", dict)  # This is always None at this time.
+        self.flags: dict[str, Any] = get_with_fallback(data, "flags", dict)  # This is always None at this time.
 
 
-class NewDisplayAsset(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
+class NewDisplayAsset(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.NewDisplayAsset
 
@@ -238,16 +238,16 @@ class NewDisplayAsset(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         to better reflect its usage across the API.
     """
 
-    __slots__: Tuple[str, ...] = ("id", "cosmetic_id", "material_instances", "render_images")
+    __slots__: tuple[str, ...] = ("id", "cosmetic_id", "material_instances", "render_images")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.id: str = data["id"]
         self.cosmetic_id: Optional[str] = data.get("cosmeticId")
-        self.material_instances: List[MaterialInstance[HTTPClientT]] = [
+        self.material_instances: list[MaterialInstance[HTTPClientT]] = [
             MaterialInstance(data=instance, http=http) for instance in get_with_fallback(data, "materialInstances", list)
         ]
-        self.render_images: List[RenderImage[HTTPClientT]] = [
+        self.render_images: list[RenderImage[HTTPClientT]] = [
             RenderImage(data=instance, http=http) for instance in get_with_fallback(data, "renderImages", list)
         ]

--- a/fortnite_api/news.py
+++ b/fortnite_api/news.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
@@ -34,11 +34,11 @@ from .utils import get_with_fallback, parse_time, simple_repr
 if TYPE_CHECKING:
     import datetime
 
-__all__: Tuple[str, ...] = ("News", "GameModeNews", "NewsMotd", "NewsMessage")
+__all__: tuple[str, ...] = ("News", "GameModeNews", "NewsMotd", "NewsMessage")
 
 
 @simple_repr
-class News(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class News(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.News
 
@@ -61,12 +61,12 @@ class News(ReconstructAble[Dict[str, Any], HTTPClientT]):
         A list of Save the World news.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "br",
         "stw",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         _br = data.get("br")
@@ -77,7 +77,7 @@ class News(ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class GameModeNews(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class GameModeNews(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.GameModeNews
 
@@ -106,9 +106,9 @@ class GameModeNews(ReconstructAble[Dict[str, Any], HTTPClientT]):
         A list of messages for the game mode.
     """
 
-    __slots__: Tuple[str, ...] = ("hash", "date", "image", "motds", "messages")
+    __slots__: tuple[str, ...] = ("hash", "date", "image", "motds", "messages")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.hash: str = data["hash"]
@@ -118,14 +118,14 @@ class GameModeNews(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.image: Optional[Asset[HTTPClientT]] = _image and Asset(http=http, url=_image)
 
         _motds = get_with_fallback(data, "motds", list)
-        self.motds: List[NewsMotd[HTTPClientT]] = [NewsMotd(data=motd, http=http) for motd in _motds]
+        self.motds: list[NewsMotd[HTTPClientT]] = [NewsMotd(data=motd, http=http) for motd in _motds]
 
         _messages = get_with_fallback(data, "messages", list)
-        self.messages: List[NewsMessage[HTTPClientT]] = [NewsMessage(data=message, http=http) for message in _messages]
+        self.messages: list[NewsMessage[HTTPClientT]] = [NewsMessage(data=message, http=http) for message in _messages]
 
 
 @simple_repr
-class NewsMotd(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
+class NewsMotd(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.NewsMotd
 
@@ -159,7 +159,7 @@ class NewsMotd(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         Whether the motd is hidden or not.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "id",
         "title",
         "tab_title",
@@ -170,7 +170,7 @@ class NewsMotd(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         "hidden",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.id: str = data["id"]
@@ -186,7 +186,7 @@ class NewsMotd(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
 
 
 @simple_repr
-class NewsMessage(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class NewsMessage(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.NewsMessage
 
@@ -213,9 +213,9 @@ class NewsMessage(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The adspace of the message.
     """
 
-    __slots__: Tuple[str, ...] = ("title", "body", "image", "adspace")
+    __slots__: tuple[str, ...] = ("title", "body", "image", "adspace")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.title: str = data["title"]

--- a/fortnite_api/playlist.py
+++ b/fortnite_api/playlist.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
@@ -35,10 +35,10 @@ if TYPE_CHECKING:
     import datetime
 
 
-__all__: Tuple[str, ...] = ('PlaylistImages', 'Playlist')
+__all__: tuple[str, ...] = ('PlaylistImages', 'Playlist')
 
 
-class PlaylistImages(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class PlaylistImages(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.PlaylistImages
 
@@ -53,9 +53,9 @@ class PlaylistImages(ReconstructAble[Dict[str, Any], HTTPClientT]):
         A mission icon for the playlist, if any.
     """
 
-    __slots__: Tuple[str, ...] = ('showcase', 'mission_icon')
+    __slots__: tuple[str, ...] = ('showcase', 'mission_icon')
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         _showcase = data.get('showcase')
@@ -65,7 +65,7 @@ class PlaylistImages(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.mission_icon: Optional[Asset[HTTPClientT]] = _mission_icon and Asset(url=_mission_icon, http=http)
 
 
-class Playlist(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
+class Playlist(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.Playlist
 
@@ -117,7 +117,7 @@ class Playlist(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         The time the playlist was added.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         'id',
         'name',
         'sub_name',
@@ -140,7 +140,7 @@ class Playlist(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         'added',
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
         self.id: str = data['id']
         self.name: str = data['name']
@@ -166,7 +166,7 @@ class Playlist(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         _images = data.get('images')
         self.images: Optional[PlaylistImages[HTTPClientT]] = _images and PlaylistImages(data=_images, http=http)
 
-        self.gameplay_tags: List[str] = get_with_fallback(data, 'gameplayTags', list)
+        self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplayTags', list)
         self.path: str = data['path']
 
         self.added: datetime.datetime = parse_time(data['added'])

--- a/fortnite_api/proxies.py
+++ b/fortnite_api/proxies.py
@@ -25,13 +25,16 @@ SOFTWARE.
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
-from typing import Callable, Generic, SupportsIndex, Union, cast, overload
+from typing import TYPE_CHECKING, Callable, Generic, SupportsIndex, Union, cast, overload
 
 from typing_extensions import Self, TypeVar
 
 T = TypeVar('T')
 K_co = TypeVar('K_co', covariant=True, default='str')
 V_co = TypeVar('V_co', covariant=True, default='Any')
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 class TransformerListProxy(Generic[T, K_co, V_co], list[T]):

--- a/fortnite_api/proxies.py
+++ b/fortnite_api/proxies.py
@@ -24,7 +24,8 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Callable, Dict, Generic, Iterable, Iterator, List, SupportsIndex, Union, cast, overload
+from collections.abc import Iterable, Iterator
+from typing import Callable, Generic, SupportsIndex, Union, cast, overload
 
 from typing_extensions import Self, TypeVar
 
@@ -33,7 +34,7 @@ K_co = TypeVar('K_co', covariant=True, default='str')
 V_co = TypeVar('V_co', covariant=True, default='Any')
 
 
-class TransformerListProxy(Generic[T, K_co, V_co], List[T]):
+class TransformerListProxy(Generic[T, K_co, V_co], list[T]):
     """
     .. attributetable:: fortnite_api.proxies.TransformerListProxy
 
@@ -52,16 +53,16 @@ class TransformerListProxy(Generic[T, K_co, V_co], List[T]):
     to ensure that the data is always in a consistent state.
     """
 
-    def __init__(self, raw_data: Iterable[Dict[K_co, V_co]], /, transform_data: Callable[[Dict[K_co, V_co]], T]) -> None:
-        self._transform_data: Callable[[Dict[K_co, V_co]], T] = transform_data
-        super().__init__(cast(List[T], raw_data))
+    def __init__(self, raw_data: Iterable[dict[K_co, V_co]], /, transform_data: Callable[[dict[K_co, V_co]], T]) -> None:
+        self._transform_data: Callable[[dict[K_co, V_co]], T] = transform_data
+        super().__init__(cast(list[T], raw_data))
 
     def _transform_at(self, index: SupportsIndex) -> T:
         # Transforms the data at the index.
         data = super().__getitem__(index)
         if isinstance(data, dict):
             # Narrow the type of data to Dict[str, Any]
-            raw_data: Dict[K_co, V_co] = data
+            raw_data: dict[K_co, V_co] = data
             result = self._transform_data(raw_data)
             super().__setitem__(index, result)
         else:
@@ -72,7 +73,7 @@ class TransformerListProxy(Generic[T, K_co, V_co], List[T]):
     def _transform_all(self):
         for index, entry in enumerate(self):
             if isinstance(entry, dict):
-                raw_data: Dict[K_co, V_co] = entry
+                raw_data: dict[K_co, V_co] = entry
                 result = self._transform_data(raw_data)
                 super().__setitem__(index, result)
 
@@ -86,9 +87,9 @@ class TransformerListProxy(Generic[T, K_co, V_co], List[T]):
     def __getitem__(self, index: SupportsIndex) -> T: ...
 
     @overload
-    def __getitem__(self, index: slice) -> List[T]: ...
+    def __getitem__(self, index: slice) -> list[T]: ...
 
-    def __getitem__(self, index: Union[SupportsIndex, slice]) -> Union[List[T], T]:
+    def __getitem__(self, index: Union[SupportsIndex, slice]) -> Union[list[T], T]:
         if isinstance(index, slice):
             # This is a slice, so we need to handle each item in the slice and set it to the transformed data.
             # For each index in the slice, transform the data at that index then update the item list
@@ -113,19 +114,19 @@ class TransformerListProxy(Generic[T, K_co, V_co], List[T]):
         return super().__reversed__()
 
     # For all the comparison methods, we need to transform all the data so that the comparison is correct.
-    def __gt__(self, value: List[T]) -> bool:
+    def __gt__(self, value: list[T]) -> bool:
         self._transform_all()
         return super().__gt__(value)
 
-    def __ge__(self, value: List[T]) -> bool:
+    def __ge__(self, value: list[T]) -> bool:
         self._transform_all()
         return super().__ge__(value)
 
-    def __lt__(self, value: List[T]) -> bool:
+    def __lt__(self, value: list[T]) -> bool:
         self._transform_all()
         return super().__lt__(value)
 
-    def __le__(self, value: List[T]) -> bool:
+    def __le__(self, value: list[T]) -> bool:
         self._transform_all()
         return super().__le__(value)
 

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import datetime
 import re
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Generator, Optional
 
 from typing_extensions import Self
 
@@ -38,6 +38,9 @@ from .http import HTTPClientT
 from .new_display_asset import NewDisplayAsset
 from .proxies import TransformerListProxy
 from .utils import get_with_fallback, parse_time
+
+if TYPE_CHECKING:
+    from .cosmetics import Cosmetic
 
 __all__: tuple[str, ...] = (
     "ShopEntryOfferTag",
@@ -463,7 +466,7 @@ class ShopEntry(ReconstructAble[dict[str, Any], HTTPClientT]):
         )
 
         _colors = data.get("colors")
-        self.colors: Optional[ShopEntryColors] = _colors and ShopEntryColors(data=_colors, http=http)
+        self.colors: Optional[ShopEntryColors[HTTPClientT]] = _colors and ShopEntryColors(data=_colors, http=http)
 
         self.br: list[CosmeticBr[HTTPClientT]] = TransformerListProxy(
             get_with_fallback(data, "brItems", list),
@@ -490,7 +493,7 @@ class ShopEntry(ReconstructAble[dict[str, Any], HTTPClientT]):
             transform_data=lambda d: CosmeticLegoKit(data=d, http=http),
         )
 
-    def __iter__(self):
+    def __iter__(self) -> Generator[Cosmetic[dict[str, Any], HTTPClientT], None, None]:
         yield from self.br
 
         yield from self.tracks

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -26,21 +26,19 @@ from __future__ import annotations
 
 import datetime
 import re
-from typing import TYPE_CHECKING, Any, Generator, Optional
+from typing import Any, Generator, Optional
 
 from typing_extensions import Self
 
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
-from .cosmetics import CosmeticBr, CosmeticCar, CosmeticInstrument, CosmeticLegoKit, CosmeticTrack
+from .cosmetics import CosmeticBr, CosmeticCar, CosmeticInstrument, CosmeticLegoKit, CosmeticTrack, Cosmetic
 from .enums import BannerIntensity
 from .http import HTTPClientT
 from .new_display_asset import NewDisplayAsset
 from .proxies import TransformerListProxy
 from .utils import get_with_fallback, parse_time
 
-if TYPE_CHECKING:
-    from .cosmetics import Cosmetic
 
 __all__: tuple[str, ...] = (
     "ShopEntryOfferTag",

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -32,13 +32,12 @@ from typing_extensions import Self
 
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
-from .cosmetics import CosmeticBr, CosmeticCar, CosmeticInstrument, CosmeticLegoKit, CosmeticTrack, Cosmetic
+from .cosmetics import Cosmetic, CosmeticBr, CosmeticCar, CosmeticInstrument, CosmeticLegoKit, CosmeticTrack
 from .enums import BannerIntensity
 from .http import HTTPClientT
 from .new_display_asset import NewDisplayAsset
 from .proxies import TransformerListProxy
 from .utils import get_with_fallback, parse_time
-
 
 __all__: tuple[str, ...] = (
     "ShopEntryOfferTag",

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import datetime
 import re
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Optional
 
 from typing_extensions import Self
 
@@ -39,7 +39,7 @@ from .new_display_asset import NewDisplayAsset
 from .proxies import TransformerListProxy
 from .utils import get_with_fallback, parse_time
 
-__all__: Tuple[str, ...] = (
+__all__: tuple[str, ...] = (
     "ShopEntryOfferTag",
     "ShopEntryBundle",
     "ShopEntryBanner",
@@ -91,7 +91,7 @@ class TileSize:
         in the format ``Size_<width>_x_<height>``.
     """
 
-    __slots__: Tuple[str, ...] = ("width", "height", "internal")
+    __slots__: tuple[str, ...] = ("width", "height", "internal")
 
     def __init__(self, *, width: int, height: int, internal: str) -> None:
         self.width: int = width
@@ -108,7 +108,7 @@ class TileSize:
         return value.width == self.width and value.height == self.height
 
     @classmethod
-    def from_value(cls: Type[Self], value: str, /) -> Self:
+    def from_value(cls: type[Self], value: str, /) -> Self:
         """Constructs a tile size from the value provided by the API. This method
         parses the passed value and ensures that it is in the correct format,
         ``Size_<width>_x_<height>``. It has been exposed in the case that
@@ -143,7 +143,7 @@ class TileSize:
         )
 
 
-class ShopEntryOfferTag(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
+class ShopEntryOfferTag(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.ShopEntryOfferTag
 
@@ -157,16 +157,16 @@ class ShopEntryOfferTag(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         The text of the offer tag.
     """
 
-    __slots__: Tuple[str, ...] = ("id", "text")
+    __slots__: tuple[str, ...] = ("id", "text")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.id: str = data["id"]
         self.text: str = data["text"]
 
 
-class ShopEntryBundle(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class ShopEntryBundle(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.ShopEntryBundle
 
@@ -182,9 +182,9 @@ class ShopEntryBundle(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The image of the bundle.
     """
 
-    __slots__: Tuple[str, ...] = ("name", "info", "image")
+    __slots__: tuple[str, ...] = ("name", "info", "image")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.name: str = data["name"]
@@ -192,7 +192,7 @@ class ShopEntryBundle(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.image: Asset[HTTPClientT] = Asset(url=data["image"], http=http)
 
 
-class ShopEntryBanner(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class ShopEntryBanner(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.ShopEntryBanner
 
@@ -209,9 +209,9 @@ class ShopEntryBanner(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The backend value of the banner.
     """
 
-    __slots__: Tuple[str, ...] = ("value", "intensity", "backend_value")
+    __slots__: tuple[str, ...] = ("value", "intensity", "backend_value")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.value: str = data["value"]
@@ -219,7 +219,7 @@ class ShopEntryBanner(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.backend_value: str = data["backendValue"]
 
 
-class ShopEntryLayout(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
+class ShopEntryLayout(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.ShopEntryLayout
 
@@ -248,7 +248,7 @@ class ShopEntryLayout(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         The display type of the layout, if any specified.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "id",
         "name",
         "category",
@@ -260,7 +260,7 @@ class ShopEntryLayout(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         "display_type",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.id: str = data["id"]
@@ -278,7 +278,7 @@ class ShopEntryLayout(Hashable, ReconstructAble[Dict[str, Any], HTTPClientT]):
         # Billboards include textureMetadata, stringMetadata and textMetadata
 
 
-class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class ShopEntryColors(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.ShopEntryColors
 
@@ -296,9 +296,9 @@ class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The fade out overlaying gradient color on which the text is displayed.
     """
 
-    __slots__: Tuple[str, ...] = ("color1", "color2", "color3", "text_background_color")
+    __slots__: tuple[str, ...] = ("color1", "color2", "color3", "text_background_color")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.color1: str = data['color1']
@@ -307,7 +307,7 @@ class ShopEntryColors(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.text_background_color: Optional[str] = data.get('textBackgroundColor')
 
 
-class ShopEntry(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class ShopEntry(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.ShopEntry
 
@@ -394,7 +394,7 @@ class ShopEntry(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The LEGO kits in this entry.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "regular_price",
         "final_price",
         "in_date",
@@ -421,7 +421,7 @@ class ShopEntry(ReconstructAble[Dict[str, Any], HTTPClientT]):
         "lego_kits",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.regular_price: int = data["regularPrice"]
@@ -465,52 +465,47 @@ class ShopEntry(ReconstructAble[Dict[str, Any], HTTPClientT]):
         _colors = data.get("colors")
         self.colors: Optional[ShopEntryColors] = _colors and ShopEntryColors(data=_colors, http=http)
 
-        self.br: List[CosmeticBr[HTTPClientT]] = TransformerListProxy(
+        self.br: list[CosmeticBr[HTTPClientT]] = TransformerListProxy(
             get_with_fallback(data, "brItems", list),
             transform_data=lambda d: CosmeticBr(data=d, http=http),
         )
 
-        self.tracks: List[CosmeticTrack[HTTPClientT]] = TransformerListProxy(
+        self.tracks: list[CosmeticTrack[HTTPClientT]] = TransformerListProxy(
             get_with_fallback(data, "tracks", list),
             transform_data=lambda d: CosmeticTrack(data=d, http=http),
         )
 
-        self.instruments: List[CosmeticInstrument[HTTPClientT]] = TransformerListProxy(
+        self.instruments: list[CosmeticInstrument[HTTPClientT]] = TransformerListProxy(
             get_with_fallback(data, "instruments", list),
             transform_data=lambda d: CosmeticInstrument(data=d, http=http),
         )
 
-        self.cars: List[CosmeticCar[HTTPClientT]] = TransformerListProxy(
+        self.cars: list[CosmeticCar[HTTPClientT]] = TransformerListProxy(
             get_with_fallback(data, "cars", list),
             transform_data=lambda d: CosmeticCar(data=d, http=http),
         )
 
-        self.lego_kits: List[CosmeticLegoKit[HTTPClientT]] = TransformerListProxy(
+        self.lego_kits: list[CosmeticLegoKit[HTTPClientT]] = TransformerListProxy(
             get_with_fallback(data, "legoKits", list),
             transform_data=lambda d: CosmeticLegoKit(data=d, http=http),
         )
 
     def __iter__(self):
-        for br in self.br:
-            yield br
+        yield from self.br
 
-        for track in self.tracks:
-            yield track
+        yield from self.tracks
 
-        for instrument in self.instruments:
-            yield instrument
+        yield from self.instruments
 
-        for car in self.cars:
-            yield car
+        yield from self.cars
 
-        for lego in self.lego_kits:
-            yield lego
+        yield from self.lego_kits
 
     def __len__(self):
         return len(self.br) + len(self.tracks) + len(self.instruments) + len(self.cars) + len(self.lego_kits)
 
 
-class Shop(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class Shop(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.Shop
 
@@ -528,14 +523,14 @@ class Shop(ReconstructAble[Dict[str, Any], HTTPClientT]):
         A list of shop entries. Each entry contains cosmetics that are available in the shop.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "hash",
         "date",
         "vbuck_icon",
         "entries",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.hash: str = data["hash"]
@@ -544,4 +539,4 @@ class Shop(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.vbuck_icon: Asset[HTTPClientT] = Asset(url=data["vbuckIcon"], http=http)
 
         _entries = get_with_fallback(data, "entries", list)
-        self.entries: List[ShopEntry[HTTPClientT]] = [ShopEntry(data=item, http=http) for item in _entries]
+        self.entries: list[ShopEntry[HTTPClientT]] = [ShopEntry(data=item, http=http) for item in _entries]

--- a/fortnite_api/stats.py
+++ b/fortnite_api/stats.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 from .abc import ReconstructAble
 from .account import Account
@@ -35,7 +35,7 @@ from .utils import parse_time
 if TYPE_CHECKING:
     import datetime
 
-__all__: Tuple[str, ...] = (
+__all__: tuple[str, ...] = (
     "BrPlayerStats",
     "BrBattlePass",
     "BrInputs",
@@ -44,7 +44,7 @@ __all__: Tuple[str, ...] = (
 )
 
 
-class BrBattlePass(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class BrBattlePass(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.BrBattlePass
 
@@ -59,16 +59,16 @@ class BrBattlePass(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The progress through the current battle pass.
     """
 
-    __slots__: Tuple[str, ...] = ("level", "progress")
+    __slots__: tuple[str, ...] = ("level", "progress")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.level: int = data["level"]
         self.progress: Optional[int] = data["progress"]
 
 
-class BrGameModeStats(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class BrGameModeStats(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.BrGameModeStats
 
@@ -132,7 +132,7 @@ class BrGameModeStats(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The date when this stat data was last updated within the Epic Games API.
     """
 
-    __slots__: Tuple[str, ...] = (
+    __slots__: tuple[str, ...] = (
         "score",
         "score_per_min",
         "score_per_match",
@@ -155,7 +155,7 @@ class BrGameModeStats(ReconstructAble[Dict[str, Any], HTTPClientT]):
         "last_modified",
     )
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.score: int = data["score"]
@@ -183,7 +183,7 @@ class BrGameModeStats(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.last_modified: datetime.datetime = parse_time(data["lastModified"])
 
 
-class BrInputStats(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class BrInputStats(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.BrInputStats
 
@@ -202,9 +202,9 @@ class BrInputStats(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The player's stats for squad game modes. This is ``None`` if the player has no stats for squad game modes.
     """
 
-    __slots__: Tuple[str, ...] = ("overall", "solo", "duo", "squad")
+    __slots__: tuple[str, ...] = ("overall", "solo", "duo", "squad")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         _overall = data.get("overall")
@@ -220,7 +220,7 @@ class BrInputStats(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.squad: Optional[BrGameModeStats[HTTPClientT]] = _squad and BrGameModeStats(data=_squad, http=http)
 
 
-class BrInputs(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class BrInputs(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.BrInputs
 
@@ -244,9 +244,9 @@ class BrInputs(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The player's stats for touch input. This is ``None`` if the player has no stats.
     """
 
-    __slots__: Tuple[str, ...] = ("all", "keyboard_mouse", "gamepad", "touch")
+    __slots__: tuple[str, ...] = ("all", "keyboard_mouse", "gamepad", "touch")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         _all = data.get("all")
@@ -264,7 +264,7 @@ class BrInputs(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.touch: Optional[BrInputStats[HTTPClientT]] = _touch and BrInputStats(data=_touch, http=http)
 
 
-class BrPlayerStats(ReconstructAble[Dict[str, Any], HTTPClientT]):
+class BrPlayerStats(ReconstructAble[dict[str, Any], HTTPClientT]):
     """
     .. attributetable:: fortnite_api.BrPlayerStats
 
@@ -316,9 +316,9 @@ class BrPlayerStats(ReconstructAble[Dict[str, Any], HTTPClientT]):
         The player's stats for all input types. This is ``None`` if the player has no stats.
     """
 
-    __slots__: Tuple[str, ...] = ("user", "battle_pass", "image", "inputs")
+    __slots__: tuple[str, ...] = ("user", "battle_pass", "image", "inputs")
 
-    def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
+    def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         _user = data["account"]

--- a/fortnite_api/utils.py
+++ b/fortnite_api/utils.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Callable, Dict, List, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, TypeVar, Union
 
 try:
     import orjson  # type: ignore
@@ -40,7 +40,7 @@ K_co = TypeVar('K_co', bound='Hashable', covariant=True)
 V_co = TypeVar('V_co', covariant=True)
 T = TypeVar('T')
 
-__all__: Tuple[str, ...] = ('parse_time', 'copy_doc', 'prepend_doc', 'to_json', 'MISSING')
+__all__: tuple[str, ...] = ('parse_time', 'copy_doc', 'prepend_doc', 'to_json', 'MISSING')
 
 BACKUP_TIMESTAMP: str = '0001-01-01T00:00:00'
 
@@ -66,12 +66,12 @@ MISSING: Any = _MissingSentinel()
 
 if _has_orjson:
 
-    def to_json(string: Union[str, bytes]) -> Dict[Any, Any]:
+    def to_json(string: Union[str, bytes]) -> dict[Any, Any]:
         return orjson.loads(string)  # type: ignore
 
 else:
 
-    def to_json(string: Union[str, bytes]) -> Dict[Any, Any]:
+    def to_json(string: Union[str, bytes]) -> dict[Any, Any]:
         return json.loads(string)  # type: ignore
 
 
@@ -151,10 +151,10 @@ def remove_prefix(text: str) -> Callable[[T], T]:
     return wrapped
 
 
-def simple_repr(cls: Type[T]) -> Type[T]:
+def simple_repr(cls: type[T]) -> type[T]:
     # If this cls does not have __slots__, return it as is
     try:
-        slots: List[str] = list(getattr(cls, '__slots__'))
+        slots: list[str] = list(getattr(cls, '__slots__'))
     except AttributeError:
         return cls
 
@@ -175,7 +175,7 @@ def simple_repr(cls: Type[T]) -> Type[T]:
     return cls
 
 
-def get_with_fallback(dict: Dict[K_co, V_co], key: K_co, default_factory: Callable[[], V_co]) -> V_co:
+def get_with_fallback(dict: dict[K_co, V_co], key: K_co, default_factory: Callable[[], V_co]) -> V_co:
     result = dict.get(key, MISSING)
     if result is MISSING:
         # Use the default factory
@@ -190,14 +190,14 @@ def get_with_fallback(dict: Dict[K_co, V_co], key: K_co, default_factory: Callab
 
 # A function name that transform some large dict into something that can be used in a get
 # request as a payload (so turns into camelCase from snake case, and transforms booleans into strings)
-def _transform_dict_for_get_request(data: Dict[str, Any]) -> Dict[str, Any]:
+def _transform_dict_for_get_request(data: dict[str, Any]) -> dict[str, Any]:
     updated = data.copy()
     for key, value in updated.items():
         if isinstance(value, bool):
             updated[key] = str(value).lower()
 
         elif isinstance(value, dict):
-            inner: Dict[str, Any] = value  # narrow the dict type to pass it along (should always be [str, Any])
+            inner: dict[str, Any] = value  # narrow the dict type to pass it along (should always be [str, Any])
             updated[key] = _transform_dict_for_get_request(inner)
 
         if '_' in key:

--- a/fortnite_api/utils.py
+++ b/fortnite_api/utils.py
@@ -25,7 +25,14 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Callable, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union
+
+K_co = TypeVar('K_co', bound='Hashable', covariant=True)
+V_co = TypeVar('V_co', covariant=True)
+T = TypeVar('T')
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable
 
 try:
     import orjson  # type: ignore
@@ -35,10 +42,6 @@ except ImportError:
     import json
 
     _has_orjson: bool = False
-
-K_co = TypeVar('K_co', bound='Hashable', covariant=True)
-V_co = TypeVar('V_co', covariant=True)
-T = TypeVar('T')
 
 __all__: tuple[str, ...] = ('parse_time', 'copy_doc', 'prepend_doc', 'to_json', 'MISSING')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ authors = [
 ]
 description = "A python wrapper for Fortnite-API.com"
 readme = "README.md"
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 license = { file = "LICENSE" }
 keywords = [
     'fortnite',
@@ -44,7 +44,6 @@ classifiers = [
     'Intended Audience :: Developers',
     'Natural Language :: English',
     'Operating System :: OS Independent',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -33,14 +33,14 @@ from fortnite_api.http import HTTPClient
 
 
 @pytest.fixture
-def sample_account_data() -> Dict[str, Any]:
+def sample_account_data() -> dict[str, Any]:
     return {
         'id': '123',
         'name': 'Test Account',
     }
 
 
-def test_account_initialization(sample_account_data: Dict[str, Any]):
+def test_account_initialization(sample_account_data: dict[str, Any]):
     account = Account(data=sample_account_data, http=HTTPClient())
 
     assert account.id == '123'
@@ -48,13 +48,13 @@ def test_account_initialization(sample_account_data: Dict[str, Any]):
     assert account.to_dict() == sample_account_data
 
 
-def test_account_str(sample_account_data: Dict[str, Any]):
+def test_account_str(sample_account_data: dict[str, Any]):
     account = Account(data=sample_account_data, http=HTTPClient())
 
     assert str(account) == 'Test Account'
 
 
-def test_account_repr(sample_account_data: Dict[str, Any]):
+def test_account_repr(sample_account_data: dict[str, Any]):
     account = Account(data=sample_account_data, http=HTTPClient())
 
     assert repr(account) == "<Account id='123', name='Test Account'>"

--- a/tests/test_aes.py
+++ b/tests/test_aes.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -34,7 +34,7 @@ from fortnite_api.http import SyncHTTPClient
 
 
 @pytest.fixture
-def sample_aes_data() -> Dict[str, Any]:
+def sample_aes_data() -> dict[str, Any]:
     return {
         'mainKey': 'test_main_key',
         'build': '++Fortnite+Release-29.10-CL-32567225-Windows',
@@ -49,7 +49,7 @@ def sample_aes_data() -> Dict[str, Any]:
     }
 
 
-def test_aes_initialization(sample_aes_data: Dict[str, Any], mock_sync_http: SyncHTTPClient):
+def test_aes_initialization(sample_aes_data: dict[str, Any], mock_sync_http: SyncHTTPClient):
     aes = Aes(data=sample_aes_data, http=mock_sync_http)
 
     assert aes.main_key == 'test_main_key'
@@ -63,7 +63,7 @@ def test_aes_initialization(sample_aes_data: Dict[str, Any], mock_sync_http: Syn
     assert aes.to_dict() == sample_aes_data
 
 
-def test_aes_equality(sample_aes_data: Dict[str, Any], mock_sync_http: SyncHTTPClient):
+def test_aes_equality(sample_aes_data: dict[str, Any], mock_sync_http: SyncHTTPClient):
     aes1 = Aes(data=sample_aes_data, http=mock_sync_http)
     aes2 = Aes(data=sample_aes_data, http=mock_sync_http)
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -25,7 +25,6 @@ SOFTWARE.
 from __future__ import annotations
 
 import dataclasses
-from typing import Dict, List
 
 from fortnite_api.proxies import TransformerListProxy
 
@@ -37,14 +36,14 @@ class PlaceholderPerson:
 
 def test_proxy():
     # A random list of people
-    people_raw_data: List[Dict[str, str]] = [
+    people_raw_data: list[dict[str, str]] = [
         dict(name="Daniel Maxwell"),
         dict(name="Francis Andrews"),
         dict(name="Stella Norton"),
         dict(name="Nathaniel Reeves"),
     ]
 
-    people: List[PlaceholderPerson] = [PlaceholderPerson(**person) for person in people_raw_data]
+    people: list[PlaceholderPerson] = [PlaceholderPerson(**person) for person in people_raw_data]
 
     proxy = TransformerListProxy(people_raw_data, transform_data=lambda data: PlaceholderPerson(**data))
 

--- a/tests/test_reconstruct.py
+++ b/tests/test_reconstruct.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, TypedDict
+from typing import Any, TypedDict
 
 import pytest
 
@@ -43,7 +43,7 @@ from fortnite_api.http import HTTPClient
 
 @pytest.mark.asyncio
 async def test_reconstruct(api_key: str) -> None:
-    methods_to_test: List[str] = [
+    methods_to_test: list[str] = [
         'fetch_cosmetics_all',
         'fetch_cosmetics_br',
         'fetch_cosmetics_cars',
@@ -78,7 +78,7 @@ async def test_reconstruct(api_key: str) -> None:
             # If this item is reconstruct-able, do some basic checks to ensure
             # that the reconstruction is working as expected.
             if isinstance(result, fortnite_api.abc.ReconstructAble):
-                narrowed: fortnite_api.abc.ReconstructAble[Dict[str, Any], HTTPClient] = result
+                narrowed: fortnite_api.abc.ReconstructAble[dict[str, Any], HTTPClient] = result
 
                 # (3) deconstruct the object
                 deconstructed = narrowed.to_dict()

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,11 +1,9 @@
-from typing import Tuple
-
 from fortnite_api.utils import simple_repr
 
 
 @simple_repr
 class Foo:
-    __slots__: Tuple[str, ...] = ('foo', 'bar', 'baz')
+    __slots__: tuple[str, ...] = ('foo', 'bar', 'baz')
 
     def __init__(self, foo: int, bar: int, baz: int) -> None:
         self.foo = foo
@@ -15,7 +13,7 @@ class Foo:
 
 @simple_repr
 class Bar(Foo):
-    __slots__: Tuple[str, ...] = ('buz',)
+    __slots__: tuple[str, ...] = ('buz',)
 
     def __init__(self, foo: int, bar: int, baz: int, buz: int) -> None:
         super().__init__(foo, bar, baz)


### PR DESCRIPTION
## Summary

This PR drops support for Python 3.8 since it has been deprecated since 2024-10-07. It removes the classifier, updates the workflow python version to 3.9 and bumps the minimum Python version to 3.9 within `pyproject.toml`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
