### PR TITLE
Add fallback value for enums

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,12 @@ New Features
 ~~~~~~~~~~~~
 - Added support for :attr:`fortnite_api.CosmeticType.SHOES`.
 
+Miscellaneous
+~~~~~~~~~~~~~
+- Add safeguards against Fortnite changes or messed up values within the API.
+    - All enums now can handle unknown values. This means that if the API returns a value that is not in the enum, it will be stored as an attribute on the enum object.
+    - :class:`fortnite_api.TileSize` now has a fallback value of width and height of 0.
+
 
 .. _vp3p1p0:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,8 +16,8 @@ New Features
 
 Miscellaneous
 ~~~~~~~~~~~~~
-- Add safeguards against Fortnite changes or messed up values within the API.
-    - All enums now can handle unknown values. This means that if the API returns a value that is not in the enum, it will be stored as an attribute on the enum object.
+- Add safeguards against Epic Games' API changing or providing invalid values in API responses.
+    - All enums now can handle unknown values via an internally defined "Enum-like" class. This means that if the API returns a value that is not in the enum, it will be stored as an attribute on the enum object.
     - :class:`fortnite_api.TileSize` now has a fallback value of width and height of 0.
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,7 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 - ``CreatorCode.status`` and ``CreatorCode.disabled`` have been removed, since they where never returned by this endpoint. Disabled creator codes always raise :class:`fortnite_api.NotFound` when trying to fetch them.
 - ``CreatorCode.verified`` has been removed, since it isn't used within the affiliate system. It always returns ``False``.
-- All enums now use an internal "Enum-like" class to handle unknown values, instead of the built-in ``enum.Enum``. This potentially breaks type checks, but it should not break core functionality.
+- All enums now use an internal "Enum-like" class to handle unknown values, instead of the built-in :class:`py.enum.Enum`. This potentially breaks type checks, but does not break core functionality or change the enum interface; you can use them the same.
 
 
 New Features
@@ -24,7 +24,7 @@ New Features
 Miscellaneous
 ~~~~~~~~~~~~~
 - Add safeguards against Epic Games' API changing or providing invalid values in API responses.
-    - All enums now can handle unknown values via an internally defined "Enum-like" class. This means that if the API returns a value that is not in the enum, it will be stored as an attribute on the enum object.
+    - All enums now can handle unknown values via an internally defined "Enum-like" class. If the API returns a value not in the enum, it will be stored as an attribute on the enum object. The interface for using this class is the same as using :class:`py.enum.Enum`.
     - :class:`fortnite_api.TileSize` now has a fallback value of width and height of 0.
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,7 @@ Miscellaneous
 ~~~~~~~~~~~~~
 - Add safeguards against Epic Games' API changing or providing invalid values in API responses.
     - All enums now can handle unknown values via an internally defined "Enum-like" class. If the API returns a value not in the enum, it will be stored as an attribute on the enum object. The interface for using this class is the same as using :class:`py:enum.Enum`.
-    - :class:`fortnite_api.TileSize` now has a fallback value of width and height of -1.
+    - :class:`fortnite_api.TileSize` no longer raises :class:`ValueError` when an unknown value is passed to it. Instead, it now has a fallback value of `-1` for both width and height.
 
 
 .. _vp3p1p0:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Breaking Changes
 ~~~~~~~~~~~~~~~~
 - ``CreatorCode.status`` and ``CreatorCode.disabled`` have been removed, since they where never returned by this endpoint. Disabled creator codes always raise :class:`fortnite_api.NotFound` when trying to fetch them.
 - ``CreatorCode.verified`` has been removed, since it isn't used within the affiliate system. It always returns ``False``.
+- All enums now use an internal "Enum-like" class to handle unknown values, instead of the built-in ``enum.Enum``. This potentially breaks type checks, but it should not break core functionality.
 
 
 New Features

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,7 @@ Miscellaneous
 ~~~~~~~~~~~~~
 - Add safeguards against Epic Games' API changing or providing invalid values in API responses.
     - All enums now can handle unknown values via an internally defined "Enum-like" class. If the API returns a value not in the enum, it will be stored as an attribute on the enum object. The interface for using this class is the same as using :class:`py:enum.Enum`.
-    - :class:`fortnite_api.TileSize` now has a fallback value of width and height of 0.
+    - :class:`fortnite_api.TileSize` now has a fallback value of width and height of -1.
 
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Breaking Changes
 - Drop support for Python 3.8. The minimum supported Python version is now 3.9.
 - ``CreatorCode.status`` and ``CreatorCode.disabled`` have been removed, since they where never returned by this endpoint. Disabled creator codes always raise :class:`fortnite_api.NotFound` when trying to fetch them.
 - ``CreatorCode.verified`` has been removed, since it isn't used within the affiliate system. It always returns ``False``.
-- All enums now use an internal "Enum-like" class to handle unknown values, instead of the built-in :class:`py.enum.Enum`. This potentially breaks type checks, but does not break core functionality or change the enum interface; you can use them the same.
+- All enums now use an internal "Enum-like" class to handle unknown values, instead of the built-in :class:`py:enum.Enum`. This potentially breaks type checks, but does not break core functionality or change the enum interface; you can use them the same.
 
 New Features
 ~~~~~~~~~~~~
@@ -24,7 +24,7 @@ New Features
 Miscellaneous
 ~~~~~~~~~~~~~
 - Add safeguards against Epic Games' API changing or providing invalid values in API responses.
-    - All enums now can handle unknown values via an internally defined "Enum-like" class. If the API returns a value not in the enum, it will be stored as an attribute on the enum object. The interface for using this class is the same as using :class:`py.enum.Enum`.
+    - All enums now can handle unknown values via an internally defined "Enum-like" class. If the API returns a value not in the enum, it will be stored as an attribute on the enum object. The interface for using this class is the same as using :class:`py:enum.Enum`.
     - :class:`fortnite_api.TileSize` now has a fallback value of width and height of 0.
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,7 +28,6 @@ Miscellaneous
     - :class:`fortnite_api.TileSize` now has a fallback value of width and height of -1.
 
 
-
 .. _vp3p1p0:
 
 v3.1.0

--- a/fortnite_api/cosmetics/common.py
+++ b/fortnite_api/cosmetics/common.py
@@ -29,7 +29,7 @@ from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
 
 from ..abc import DictT, Hashable, ReconstructAble
 from ..asset import Asset
-from ..enums import CosmeticRarity, CosmeticType
+from ..enums import CosmeticRarity, CosmeticType, try_enum
 from ..http import HTTPClientT
 from ..images import Images
 from ..utils import get_with_fallback, parse_time, simple_repr
@@ -125,7 +125,7 @@ class CosmeticTypeInfo(ReconstructAble[Dict[str, Any], HTTPClientT]):
     def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
-        self.value: CosmeticType = CosmeticType(data["value"])
+        self.value: CosmeticType = try_enum(CosmeticType, data["value"])
         self.raw_value: str = data["value"]
 
         self.display_value: str = data["displayValue"]
@@ -162,7 +162,7 @@ class CosmeticRarityInfo(ReconstructAble[Dict[str, Any], HTTPClientT]):
     def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
-        self.value: CosmeticRarity = CosmeticRarity(data["value"])
+        self.value: CosmeticRarity = try_enum(CosmeticRarity, data["value"])
         self.display_value: str = data["displayValue"]
         self.backend_value: str = data["backendValue"]
 

--- a/fortnite_api/cosmetics/variants/bean.py
+++ b/fortnite_api/cosmetics/variants/bean.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Coroutine, Dict, List, Optional, Union, overload
 
-from ...enums import CustomGender, GameLanguage
+from ...enums import CustomGender, GameLanguage, try_enum
 from ...http import HTTPClientT
 from ...utils import get_with_fallback
 from ..br import CosmeticBr
@@ -73,7 +73,7 @@ class VariantBean(Cosmetic[Dict[str, Any], HTTPClientT]):
 
         self.cosmetic_id: Optional[str] = data.get('cosmetic_id')
         self.name: str = data['name']
-        self.gender: CustomGender = CustomGender(data['gender'])
+        self.gender: CustomGender = try_enum(CustomGender, data['gender'])
         self.gameplay_tags: List[str] = get_with_fallback(data, 'gameplay_tags', list)
 
         _images = data.get('images')

--- a/fortnite_api/creator_code.py
+++ b/fortnite_api/creator_code.py
@@ -75,7 +75,7 @@ class CreatorCode(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.code: str = data["code"]
         self.account: Account[HTTPClientT] = Account(data=data["account"], http=http)
         self.verified: bool = data["verified"]
-        self.status: CreatorCodeStatus = try_enum(CreatorCodeStatus, data["status"])
+        self.status: CreatorCodeStatus = try_enum(CreatorCodeStatus, data["status"].lower())
 
     @property
     def disabled(self) -> bool:

--- a/fortnite_api/creator_code.py
+++ b/fortnite_api/creator_code.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, Tuple
 
 from .abc import ReconstructAble
 from .account import Account
-from .enums import CreatorCodeStatus
+from .enums import CreatorCodeStatus, try_enum
 from .http import HTTPClientT
 from .utils import simple_repr
 
@@ -75,7 +75,7 @@ class CreatorCode(ReconstructAble[Dict[str, Any], HTTPClientT]):
         self.code: str = data["code"]
         self.account: Account[HTTPClientT] = Account(data=data["account"], http=http)
         self.verified: bool = data["verified"]
-        self.status: CreatorCodeStatus = CreatorCodeStatus(data["status"].lower())
+        self.status: CreatorCodeStatus = try_enum(CreatorCodeStatus, data["status"])
 
     @property
     def disabled(self) -> bool:

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -25,9 +25,11 @@ SOFTWARE.
 from __future__ import annotations
 
 import enum
-from typing import Type
+from typing import Any, Type, TypeVar
 
 from typing_extensions import Self
+
+E = TypeVar('E', bound='Enum')
 
 
 class KeyFormat(enum.Enum):
@@ -436,3 +438,21 @@ class ProductTag(enum.Enum):
         # To easily handle this, we'll remove the "Product." prefix and convert it to lowercase.
         trimmed = string.split('.')[-1]
         return cls(trimmed.lower())
+
+
+def create_unknown_value(cls: Type[E], val: Any) -> E:
+    value_cls = cls._enum_value_cls_  # type: ignore # This is narrowed below
+    name = f'unknown_{val}'
+    return value_cls(name=name, value=val)
+
+
+def try_enum(cls: Type[E], val: Any) -> E:
+    """A function that tries to turn the value into enum ``cls``.
+
+    If it fails it returns a proxy invalid value instead.
+    """
+
+    try:
+        return cls._enum_value_map_[val]  # type: ignore # All errors are caught below
+    except (KeyError, TypeError, AttributeError):
+        return create_unknown_value(cls, val)

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -2,6 +2,7 @@
 MIT License
 
 Copyright (c) 2019-present Luc1412
+Portions of this code are Copyright (c) 2015-present Rapptz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -26,8 +26,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import types
-from collections import namedtuple
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Mapping, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Mapping, NamedTuple, Tuple, Type, TypeVar
 
 from typing_extensions import Self
 
@@ -52,10 +51,15 @@ E = TypeVar('E', bound='Enum')
 OldValue = NewValue = Any
 
 
-def _create_value_cls(name: str, comparable: bool):
+def _create_value_cls(name: str, comparable: bool) -> Type[NamedTuple]:
     # Pyright cannot statically recognize the runtime type creation. All of the following
     # type ignores in this function are a result of this.
-    cls = namedtuple('_EnumValue_' + name, 'name value')
+    class _EnumValue(NamedTuple):
+        name: str
+        value: Any
+
+    cls = _EnumValue
+    cls.__name__ = '_EnumValue_' + name
     cls.__repr__ = lambda self: f'<{name}.{self.name}: {self.value!r}>'  # type: ignore
     cls.__str__ = lambda self: f'{name}.{self.name}'  # type: ignore
     if comparable:

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -26,7 +26,8 @@ SOFTWARE.
 from __future__ import annotations
 
 import types
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Mapping, NamedTuple, Tuple, Type, TypeVar
+from collections import namedtuple
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Mapping, Tuple, Type, TypeVar
 
 from typing_extensions import Self
 
@@ -51,20 +52,17 @@ E = TypeVar('E', bound='Enum')
 OldValue = NewValue = Any
 
 
-class _EnumValue(NamedTuple):
-    name: str
-    value: Any
-
-
-def _create_value_cls(name: str, comparable: bool) -> Type[_EnumValue]:
-    cls = _EnumValue
-    cls.__repr__ = lambda self: f'<{name}.{self.name}: {self.value!r}>'
-    cls.__str__ = lambda self: f'{name}.{self.name}'
+def _create_value_cls(name: str, comparable: bool):
+    # Pyright cannot statically recognize the runtime type creation. All of the following
+    # type ignores in this function are a result of this.
+    cls = namedtuple('_EnumValue_' + name, 'name value')
+    cls.__repr__ = lambda self: f'<{name}.{self.name}: {self.value!r}>'  # type: ignore
+    cls.__str__ = lambda self: f'{name}.{self.name}'  # type: ignore
     if comparable:
-        cls.__le__ = lambda self, other: isinstance(other, self.__class__) and self.value <= other.value
-        cls.__ge__ = lambda self, other: isinstance(other, self.__class__) and self.value >= other.value
-        cls.__lt__ = lambda self, other: isinstance(other, self.__class__) and self.value < other.value
-        cls.__gt__ = lambda self, other: isinstance(other, self.__class__) and self.value > other.value
+        cls.__le__ = lambda self, other: isinstance(other, self.__class__) and self.value <= other.value  # type: ignore
+        cls.__ge__ = lambda self, other: isinstance(other, self.__class__) and self.value >= other.value  # type: ignore
+        cls.__lt__ = lambda self, other: isinstance(other, self.__class__) and self.value < other.value  # type: ignore
+        cls.__gt__ = lambda self, other: isinstance(other, self.__class__) and self.value > other.value  # type: ignore
 
     return cls
 

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -24,7 +24,6 @@ SOFTWARE.
 
 from __future__ import annotations
 
-import enum
 import types
 from collections import namedtuple
 from typing import Any, Type, TypeVar, TYPE_CHECKING, ClassVar, List, Dict, Tuple, Iterator, Mapping
@@ -156,7 +155,7 @@ else:
                 return value
 
 
-class KeyFormat(enum.Enum):
+class KeyFormat(Enum):
     """Represents a return format type for the AES endpoint.
 
     Attributes
@@ -171,7 +170,7 @@ class KeyFormat(enum.Enum):
     BASE64 = 'base64'
 
 
-class GameLanguage(enum.Enum):
+class GameLanguage(Enum):
     """Represents a language that Fortnite supports. This can be
     used to change the return language of many API calls.
 
@@ -226,7 +225,7 @@ class GameLanguage(enum.Enum):
     CHINESE_TRADITIONAL = 'zh-Hant'
 
 
-class MatchMethod(enum.Enum):
+class MatchMethod(Enum):
     """Represents a string matching method for some search methods in the API.
 
     Attributes
@@ -247,7 +246,7 @@ class MatchMethod(enum.Enum):
     ENDS = 'ends'
 
 
-class CosmeticCategory(enum.Enum):
+class CosmeticCategory(Enum):
     """Represents the internal names for the types of a cosmetics in Fortnite.
 
     Attributes
@@ -277,7 +276,7 @@ class CosmeticCategory(enum.Enum):
     BEANS = "beans"
 
 
-class CosmeticRarity(enum.Enum):
+class CosmeticRarity(Enum):
     """Represents a rarity of a :class:`~fortnite_api.Cosmetic` object.
 
     Attributes
@@ -319,7 +318,7 @@ class CosmeticRarity(enum.Enum):
     MYTHIC = 'mythic'
 
 
-class CosmeticType(enum.Enum):
+class CosmeticType(Enum):
     """Represents a type of a :class:`fortnite_api.CosmeticBr` cosmetic.
 
     Attributes
@@ -396,7 +395,7 @@ class CosmeticType(enum.Enum):
     SHOUT = 'shout'
 
 
-class AccountType(enum.Enum):
+class AccountType(Enum):
     """Represents the type of a :class:`fortnite_api.account.Account`.
 
     Attributes
@@ -414,7 +413,7 @@ class AccountType(enum.Enum):
     XBL = 'xbl'
 
 
-class TimeWindow(enum.Enum):
+class TimeWindow(Enum):
     """Represents a time window for statistics in the API.
 
     Attributes
@@ -429,7 +428,7 @@ class TimeWindow(enum.Enum):
     LIFETIME = 'lifetime'
 
 
-class StatsImageType(enum.Enum):
+class StatsImageType(Enum):
     """Represents the type of image that should be returned from the stats image endpoint.
 
     Attributes
@@ -453,7 +452,7 @@ class StatsImageType(enum.Enum):
     NONE = 'none'
 
 
-class CreatorCodeStatus(enum.Enum):
+class CreatorCodeStatus(Enum):
     """Represents the status of a creator code.
 
     Attributes
@@ -468,7 +467,7 @@ class CreatorCodeStatus(enum.Enum):
     DISABLED = 'disabled'
 
 
-class CosmeticCompatibleMode(enum.Enum):
+class CosmeticCompatibleMode(Enum):
     """A class that represents the compatibility of a cosmetic :class:`fortnite_api.MaterialInstance` with other modes.
 
     Attributes
@@ -501,7 +500,7 @@ class CosmeticCompatibleMode(enum.Enum):
         return cls(trimmed.lower())
 
 
-class BannerIntensity(enum.Enum):
+class BannerIntensity(Enum):
     """Denotes the intensity of a :class:`fortnite_api.ShopEntryBanner`.
 
     Attributes
@@ -516,7 +515,7 @@ class BannerIntensity(enum.Enum):
     HIGH = 'High'
 
 
-class CustomGender(enum.Enum):
+class CustomGender(Enum):
     """Denotes the gender of a character in Fortnite.
 
     At the moment, this is only used on the :class:`fortnite_api.VariantBean` class.
@@ -533,7 +532,7 @@ class CustomGender(enum.Enum):
     MALE = 'EFortCustomGender::Male'
 
 
-class ProductTag(enum.Enum):
+class ProductTag(Enum):
     """A class that represents the tag of a product.
 
     Attributes

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -62,7 +62,7 @@ def _create_value_cls(name: str, comparable: bool):
         cls.__ge__ = lambda self, other: isinstance(other, self.__class__) and self.value >= other.value  # type: ignore
         cls.__lt__ = lambda self, other: isinstance(other, self.__class__) and self.value < other.value  # type: ignore
         cls.__gt__ = lambda self, other: isinstance(other, self.__class__) and self.value > other.value  # type: ignore
-    
+
     return cls
 
 

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -26,11 +26,12 @@ from __future__ import annotations
 
 import types
 from collections import namedtuple
-from typing import Any, Type, TypeVar, TYPE_CHECKING, ClassVar, List, Dict, Tuple, Iterator, Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Mapping, Tuple, Type, TypeVar
 
 from typing_extensions import Self
 
 E = TypeVar('E', bound='Enum')
+
 
 def _create_value_cls(name: str, comparable: bool):
     # All the type ignores here are due to the type checker being unable to recognise
@@ -58,12 +59,12 @@ class EnumMeta(type):
         _enum_value_map_: ClassVar[Dict[Any, Any]]
 
     def __new__(
-            cls,
-            name: str,
-            bases: Tuple[type, ...],
-            attrs: Dict[str, Any],
-            *,
-            comparable: bool = False,
+        cls,
+        name: str,
+        bases: Tuple[type, ...],
+        attrs: Dict[str, Any],
+        *,
+        comparable: bool = False,
     ) -> EnumMeta:
         value_mapping = {}
         member_mapping = {}

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -49,6 +49,7 @@ __all__: Tuple[str, ...] = (
 
 
 E = TypeVar('E', bound='Enum')
+OldValue = NewValue = Any
 
 
 def _create_value_cls(name: str, comparable: bool):

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -499,7 +499,7 @@ class CosmeticCompatibleMode(Enum):
         # To easily handle this, we'll remove the "ECosmeticCompatibleMode::" or "ECosmeticCompatibleModeLegacy::" prefix.
         # and then convert it to the enum.
         trimmed = string.split('::')[-1]
-        return cls(trimmed.lower())
+        return try_enum(cls, trimmed)
 
 
 class BannerIntensity(Enum):
@@ -562,7 +562,7 @@ class ProductTag(Enum):
         # The Epic Games API "Product" enums contains both lower case and capitalized values, so we need to handle both.
         # To easily handle this, we'll remove the "Product." prefix and convert it to lowercase.
         trimmed = string.split('.')[-1]
-        return cls(trimmed.lower())
+        return try_enum(cls, trimmed.lower())
 
 
 def create_unknown_value(cls: Type[E], val: Any) -> E:

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -26,8 +26,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import types
-from collections import namedtuple
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Mapping, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Mapping, NamedTuple, Tuple, Type, TypeVar
 
 from typing_extensions import Self
 
@@ -52,17 +51,20 @@ E = TypeVar('E', bound='Enum')
 OldValue = NewValue = Any
 
 
-def _create_value_cls(name: str, comparable: bool):
-    # Pyright cannot statically recognize the runtime type creation. All of the following
-    # type ignores in this function are a result of this.
-    cls = namedtuple('_EnumValue_' + name, 'name value')
-    cls.__repr__ = lambda self: f'<{name}.{self.name}: {self.value!r}>'  # type: ignore
-    cls.__str__ = lambda self: f'{name}.{self.name}'  # type: ignore
+class _EnumValue(NamedTuple):
+    name: str
+    value: Any
+
+
+def _create_value_cls(name: str, comparable: bool) -> Type[_EnumValue]:
+    cls = _EnumValue
+    cls.__repr__ = lambda self: f'<{name}.{self.name}: {self.value!r}>'
+    cls.__str__ = lambda self: f'{name}.{self.name}'
     if comparable:
-        cls.__le__ = lambda self, other: isinstance(other, self.__class__) and self.value <= other.value  # type: ignore
-        cls.__ge__ = lambda self, other: isinstance(other, self.__class__) and self.value >= other.value  # type: ignore
-        cls.__lt__ = lambda self, other: isinstance(other, self.__class__) and self.value < other.value  # type: ignore
-        cls.__gt__ = lambda self, other: isinstance(other, self.__class__) and self.value > other.value  # type: ignore
+        cls.__le__ = lambda self, other: isinstance(other, self.__class__) and self.value <= other.value
+        cls.__ge__ = lambda self, other: isinstance(other, self.__class__) and self.value >= other.value
+        cls.__lt__ = lambda self, other: isinstance(other, self.__class__) and self.value < other.value
+        cls.__gt__ = lambda self, other: isinstance(other, self.__class__) and self.value > other.value
 
     return cls
 

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -25,11 +25,135 @@ SOFTWARE.
 from __future__ import annotations
 
 import enum
-from typing import Any, Type, TypeVar
+import types
+from collections import namedtuple
+from typing import Any, Type, TypeVar, TYPE_CHECKING, ClassVar, List, Dict, Tuple, Iterator, Mapping
 
 from typing_extensions import Self
 
 E = TypeVar('E', bound='Enum')
+
+def _create_value_cls(name: str, comparable: bool):
+    # All the type ignores here are due to the type checker being unable to recognise
+    # Runtime type creation without exploding.
+    cls = namedtuple('_EnumValue_' + name, 'name value')
+    cls.__repr__ = lambda self: f'<{name}.{self.name}: {self.value!r}>'  # type: ignore
+    cls.__str__ = lambda self: f'{name}.{self.name}'  # type: ignore
+    if comparable:
+        cls.__le__ = lambda self, other: isinstance(other, self.__class__) and self.value <= other.value  # type: ignore
+        cls.__ge__ = lambda self, other: isinstance(other, self.__class__) and self.value >= other.value  # type: ignore
+        cls.__lt__ = lambda self, other: isinstance(other, self.__class__) and self.value < other.value  # type: ignore
+        cls.__gt__ = lambda self, other: isinstance(other, self.__class__) and self.value > other.value  # type: ignore
+    return cls
+
+
+def _is_descriptor(obj):
+    return hasattr(obj, '__get__') or hasattr(obj, '__set__') or hasattr(obj, '__delete__')
+
+
+class EnumMeta(type):
+    if TYPE_CHECKING:
+        __name__: ClassVar[str]
+        _enum_member_names_: ClassVar[List[str]]
+        _enum_member_map_: ClassVar[Dict[str, Any]]
+        _enum_value_map_: ClassVar[Dict[Any, Any]]
+
+    def __new__(
+            cls,
+            name: str,
+            bases: Tuple[type, ...],
+            attrs: Dict[str, Any],
+            *,
+            comparable: bool = False,
+    ) -> EnumMeta:
+        value_mapping = {}
+        member_mapping = {}
+        member_names = []
+
+        value_cls = _create_value_cls(name, comparable)
+        for key, value in list(attrs.items()):
+            is_descriptor = _is_descriptor(value)
+            if key[0] == '_' and not is_descriptor:
+                continue
+
+            # Special case classmethod to just pass through
+            if isinstance(value, classmethod):
+                continue
+
+            if is_descriptor:
+                setattr(value_cls, key, value)
+                del attrs[key]
+                continue
+
+            try:
+                new_value = value_mapping[value]
+            except KeyError:
+                new_value = value_cls(name=key, value=value)
+                value_mapping[value] = new_value
+                member_names.append(key)
+
+            member_mapping[key] = new_value
+            attrs[key] = new_value
+
+        attrs['_enum_value_map_'] = value_mapping
+        attrs['_enum_member_map_'] = member_mapping
+        attrs['_enum_member_names_'] = member_names
+        attrs['_enum_value_cls_'] = value_cls
+        actual_cls = super().__new__(cls, name, bases, attrs)
+        value_cls._actual_enum_cls_ = actual_cls  # type: ignore # Runtime attribute isn't understood
+        return actual_cls
+
+    def __iter__(cls) -> Iterator[Any]:
+        return (cls._enum_member_map_[name] for name in cls._enum_member_names_)
+
+    def __reversed__(cls) -> Iterator[Any]:
+        return (cls._enum_member_map_[name] for name in reversed(cls._enum_member_names_))
+
+    def __len__(cls) -> int:
+        return len(cls._enum_member_names_)
+
+    def __repr__(cls) -> str:
+        return f'<enum {cls.__name__}>'
+
+    @property
+    def __members__(cls) -> Mapping[str, Any]:
+        return types.MappingProxyType(cls._enum_member_map_)
+
+    def __call__(cls, value: str) -> Any:
+        try:
+            return cls._enum_value_map_[value]
+        except (KeyError, TypeError):
+            raise ValueError(f"{value!r} is not a valid {cls.__name__}")
+
+    def __getitem__(cls, key: str) -> Any:
+        return cls._enum_member_map_[key]
+
+    def __setattr__(cls, name: str, value: Any) -> None:
+        raise TypeError('Enums are immutable.')
+
+    def __delattr__(cls, attr: str) -> None:
+        raise TypeError('Enums are immutable')
+
+    def __instancecheck__(self, instance: Any) -> bool:
+        # isinstance(x, Y)
+        # -> __instancecheck__(Y, x)
+        try:
+            return instance._actual_enum_cls_ is self
+        except AttributeError:
+            return False
+
+
+if TYPE_CHECKING:
+    from enum import Enum
+else:
+
+    class Enum(metaclass=EnumMeta):
+        @classmethod
+        def try_value(cls, value):
+            try:
+                return cls._enum_value_map_[value]
+            except (KeyError, TypeError):
+                return value
 
 
 class KeyFormat(enum.Enum):

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -26,7 +26,8 @@ SOFTWARE.
 from __future__ import annotations
 
 import types
-from typing import TYPE_CHECKING, Any, ClassVar, Iterator, Mapping, NamedTuple, TypeVar
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TypeVar
 
 from typing_extensions import Self
 

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -26,7 +26,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import types
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Mapping, NamedTuple, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterator, List, Mapping, NamedTuple, Tuple, Type, TypeVar
 
 from typing_extensions import Self
 
@@ -48,7 +48,7 @@ __all__: Tuple[str, ...] = (
 
 
 E = TypeVar('E', bound='Enum')
-OldValue = NewValue = Any
+OldValue = Any
 
 
 # Denotes an internal marker used to create the value class.
@@ -171,7 +171,7 @@ class Enum(metaclass=EnumMeta):
         _enum_value_cls_: ClassVar[Type[_EnumValue]]
 
     @classmethod
-    def try_value(cls, value: OldValue) -> Union[OldValue, NewValue]:
+    def try_value(cls, value: Any) -> Any:
         try:
             return cls._enum_value_map_[value]
         except (KeyError, TypeError):

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -567,7 +567,7 @@ class ProductTag(Enum):
 
 def create_unknown_value(cls: Type[E], val: Any) -> E:
     value_cls = cls._enum_value_cls_  # type: ignore # This is narrowed below
-    name = f'unknown_{val}'
+    name = f'UNKNOWN_{val}'
     return value_cls(name=name, value=val)
 
 

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -84,9 +84,9 @@ class TileSize:
     Attributes
     ----------
     width: :class:`int`
-        The width of the tile.
+        The width of the tile. This value will be -1 if the tile size is invalid.
     height: :class:`int`
-        The height of the tile.
+        The height of the tile. This value will be -1 if the tile size is invalid.
     internal: :class:`str`
         The internal representation of the tile size. This can be the default Epic API value
         in the format ``Size_<width>_x_<height>``.
@@ -115,7 +115,7 @@ class TileSize:
         ``Size_<width>_x_<height>``. It has been exposed in the case that
         the user wants to construct a tile size from a custom value.
 
-        If an invalid value is passed, the tile size defaults to a width and height of 0.
+        If an invalid value is passed, the tile size defaults to a width and height of -1.
 
         Parameters
         ----------
@@ -132,7 +132,7 @@ class TileSize:
         if not match:
             # Epic may change the format or messes up the value.
             # In one such case, this value was "ERROR BAD SIZE".
-            raise cls(width=0, height=0, internal=value)
+            raise cls(width=-1, height=-1, internal=value)
 
         return cls(
             width=int(match.group("width")),

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -114,6 +114,8 @@ class TileSize:
         ``Size_<width>_x_<height>``. It has been exposed in the case that
         the user wants to construct a tile size from a custom value.
 
+        If an invalid value is passed, the tile size defaults to 1x1.
+
         Parameters
         ----------
         value: :class:`str`
@@ -123,18 +125,13 @@ class TileSize:
         -------
         :class:`TileSize`
             The constructed tile size.
-
-        Raises
-        ------
-        ValueError
-            If the value is not in the correct format.
         """
         # Try and match the regex
         match = _TILE_SIZE_REGEX.match(value)
         if not match:
-            # Epic only uses the tile sizing on the regex. If there isn't a match
-            # we can safely assume an exception must be raised
-            raise ValueError(f"Invalid tile size: {value!r}")
+            # Epic may change the format or messes up the value.
+            # In one such case, this value was "ERROR BAD SIZE".
+            raise cls(width=1, height=1, internal=value)
 
         return cls(
             width=int(match.group("width")),

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -114,7 +114,7 @@ class TileSize:
         ``Size_<width>_x_<height>``. It has been exposed in the case that
         the user wants to construct a tile size from a custom value.
 
-        If an invalid value is passed, the tile size defaults to 1x1.
+        If an invalid value is passed, the tile size defaults to a width and height of 0.
 
         Parameters
         ----------
@@ -131,7 +131,7 @@ class TileSize:
         if not match:
             # Epic may change the format or messes up the value.
             # In one such case, this value was "ERROR BAD SIZE".
-            raise cls(width=1, height=1, internal=value)
+            raise cls(width=0, height=0, internal=value)
 
         return cls(
             width=int(match.group("width")),

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -33,7 +33,7 @@ from typing_extensions import Self
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
 from .cosmetics import CosmeticBr, CosmeticCar, CosmeticInstrument, CosmeticLegoKit, CosmeticTrack
-from .enums import BannerIntensity
+from .enums import BannerIntensity, try_enum
 from .http import HTTPClientT
 from .new_display_asset import NewDisplayAsset
 from .proxies import TransformerListProxy
@@ -215,7 +215,7 @@ class ShopEntryBanner(ReconstructAble[Dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         self.value: str = data["value"]
-        self.intensity: BannerIntensity = BannerIntensity(data["intensity"])
+        self.intensity: BannerIntensity = try_enum(BannerIntensity, data["intensity"])
         self.backend_value: str = data["backendValue"]
 
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -27,18 +27,50 @@ from fortnite_api.enums import Enum, try_enum
 
 class DummyEnum(Enum):
     FOO = "foo"
-    BAR = "bar"
+    BAR = "bar" 
     BAZ = "baz"
 
 
 def test_dummy_enum():
+    # Test basic enum functionality
+    assert len(DummyEnum) == 3
+    assert list(DummyEnum) == [DummyEnum.FOO, DummyEnum.BAR, DummyEnum.BAZ]
+    assert list(reversed(DummyEnum)) == [DummyEnum.BAZ, DummyEnum.BAR, DummyEnum.FOO]
+    
+    # Test enum member access
+    assert DummyEnum.FOO.name == "FOO"
+    assert DummyEnum.FOO.value == "foo"
+    assert DummyEnum["FOO"] == DummyEnum.FOO
+    assert DummyEnum("foo") == DummyEnum.FOO
+    
+    # Test immutability
+    with pytest.raises(TypeError):
+        DummyEnum.FOO = "new"
+    with pytest.raises(TypeError):
+        del DummyEnum.FOO
+        
+    # Test try_enum functionality
     valid_value = "foo"
     invalid_value = "invalid"
 
     valid_instance = try_enum(DummyEnum, valid_value)
     assert valid_instance == DummyEnum.FOO
     assert valid_instance.value == valid_value
+    assert isinstance(valid_instance, DummyEnum)
 
     invalid_instance = try_enum(DummyEnum, invalid_value)
     assert invalid_instance.name == f"UNKNOWN_{invalid_value}"
     assert invalid_instance.value == invalid_value
+    assert isinstance(invalid_instance, DummyEnum)
+
+    # Test string representations
+    assert str(DummyEnum.FOO) == "DummyEnum.FOO"
+    assert repr(DummyEnum.FOO) == "<DummyEnum.FOO: 'foo'>"
+    assert repr(DummyEnum) == "<enum DummyEnum>"
+
+    # Test members property
+    assert DummyEnum.__members__ == {
+        "FOO": DummyEnum.FOO,
+        "BAR": DummyEnum.BAR,
+        "BAZ": DummyEnum.BAZ
+    }

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -23,6 +23,7 @@ SOFTWARE.
 """
 
 import pytest
+
 from fortnite_api.enums import Enum, try_enum
 
 
@@ -37,19 +38,19 @@ def test_dummy_enum():
     assert len(DummyEnum) == 3
     assert list(DummyEnum) == [DummyEnum.FOO, DummyEnum.BAR, DummyEnum.BAZ]
     assert list(reversed(DummyEnum)) == [DummyEnum.BAZ, DummyEnum.BAR, DummyEnum.FOO]
-    
+
     # Test enum member access
     assert DummyEnum.FOO.name == "FOO"
     assert DummyEnum.FOO.value == "foo"
     assert DummyEnum["FOO"] == DummyEnum.FOO
     assert DummyEnum("foo") == DummyEnum.FOO
-    
+
     # Test immutability
     with pytest.raises(TypeError):
         DummyEnum.FOO = "new"
     with pytest.raises(TypeError):
         del DummyEnum.FOO
-        
+
     # Test try_enum functionality
     valid_value = "foo"
     invalid_value = "invalid"
@@ -70,8 +71,4 @@ def test_dummy_enum():
     assert repr(DummyEnum) == "<enum DummyEnum>"
 
     # Test members property
-    assert DummyEnum.__members__ == {
-        "FOO": DummyEnum.FOO,
-        "BAR": DummyEnum.BAR,
-        "BAZ": DummyEnum.BAZ
-    }
+    assert DummyEnum.__members__ == {"FOO": DummyEnum.FOO, "BAR": DummyEnum.BAR, "BAZ": DummyEnum.BAZ}

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -38,5 +38,5 @@ def test_dummy_enum():
     assert valid_instance.value == valid_value
 
     invalid_instance = try_enum(DummyEnum, invalid_value)
-    assert invalid_instance.name == f'"UNKNOWN_{invalid_value}"'
+    assert invalid_instance.name == f"UNKNOWN_{invalid_value}"
     assert invalid_instance.value == invalid_value

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -22,12 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+import pytest
 from fortnite_api.enums import Enum, try_enum
 
 
 class DummyEnum(Enum):
     FOO = "foo"
-    BAR = "bar" 
+    BAR = "bar"
     BAZ = "baz"
 
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,0 +1,42 @@
+"""
+MIT License
+
+Copyright (c) 2019-present Luc1412
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+from fortnite_api import Enum, try_enum
+
+
+class DummyEnum(Enum):
+    FOO = "foo"
+    BAR = "bar"
+    BAZ = "baz"
+
+def test_dummy_enum():
+    valid_value = "foo"
+    invalid_value = "invalid"
+
+    valid_instance = try_enum(DummyEnum, valid_value)
+    assert valid_instance == DummyEnum.FOO
+    assert valid_instance.value == valid_value
+
+    invalid_instance = try_enum(DummyEnum, invalid_value)
+    assert invalid_instance.name == f'"UNKNOWN_{invalid_value}"'
+    assert invalid_instance.value == invalid_value

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -21,13 +21,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-from fortnite_api import Enum, try_enum
+
+from fortnite_api.enums import Enum, try_enum
 
 
 class DummyEnum(Enum):
     FOO = "foo"
     BAR = "bar"
     BAZ = "baz"
+
 
 def test_dummy_enum():
     valid_value = "foo"


### PR DESCRIPTION
## Summary

It's not unlikely that Epic may add new stuff or messes things up. This could result in the library completely breaking for some endpoints. To prevent this fallback values need to be added.

To solve this issue, enums are parsed with `try_enum`. This will create a fallback unknown enum value in such case.

## TODO:
- [x] Write tests for Enum
- [x] Properly credit Discord.py and Danny, hence code is being used from discord.py repo with MIT license
- [x] Properly apply `try_enum` to Enums that are constructed from a classmethod (`CosmeticCompatibleMode`, `ProductTag`)
- [x] Apply fallback values to other customs classes including `TileSize`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
