### PR TITLE
Remove deprecated attributes of the Creator Code endpoint

### DIFF
--- a/docs/api/objects.rst
+++ b/docs/api/objects.rst
@@ -226,9 +226,6 @@ Enumerations
 .. autoclass:: fortnite_api.StatsImageType
     :members:
 
-.. autoclass:: fortnite_api.CreatorCodeStatus
-    :members:
-
 .. autoclass:: fortnite_api.CosmeticCompatibleMode
     :members:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,16 @@
 Changelog
 =========
 
+.. _vp3p2p0:
+
+v3.2.0
+-------
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+- ``CreatorCode.status`` and ``CreatorCode.disabled`` have been removed, since they where never returned by this endpoint. Disabled creator codes always raise :class:`fortnite_api.NotFound` when trying to fetch them.
+- ``CreatorCode.verified`` has been removed, since it isn't used within the affiliate system. It always returns ``False``.
+
 .. _vp3p1p0:
 
 v3.1.0

--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -892,8 +892,6 @@ work with the library and upgrade from Version 2. Every object not already menti
 
 - :class:`fortnite_api.StatsImageType`: An enum that represents which type of battle royale statistics image type should be returned from the API when fetching BR stats. This is used as a parameter when fetching BR stats. 
 
-- :class:`fortnite_api.CreatorCodeStatus`: An enum that represents if a creator code is active or not. This is used in a :class:`~fortnite_api.CreatorCode` object.
-
 - :class:`fortnite_api.BannerIntensity`: An enum that represents the intensity of a banner color. This is used in the :class:`~fortnite_api.ShopEntryBanner` class to represent the intensity of a banner color.
 
 - :class:`fortnite_api.FortniteAPIException` and all its subclasses found in :ref:`the exception hierarchy <api-exception-hierarchy>`: These are exceptions that are raised when an error occurs while fetching data from the Fortnite API. They are used across the library. For what each of them do, see the :ref:`exception hierarchy <api-exception-hierarchy>`.

--- a/fortnite_api/client.py
+++ b/fortnite_api/client.py
@@ -829,7 +829,7 @@ class Client:
         Raises
         ------
         NotFound
-            A creator code with that name was not found.
+            A creator code with that name doesn't exist or has been disabled.
         """
         data = await self.http.get_creator_code(name)
         return CreatorCode(data=data, http=self.http)

--- a/fortnite_api/creator_code.py
+++ b/fortnite_api/creator_code.py
@@ -28,7 +28,6 @@ from typing import Any, Dict, Tuple
 
 from .abc import ReconstructAble
 from .account import Account
-from .enums import CreatorCodeStatus
 from .http import HTTPClientT
 from .utils import simple_repr
 
@@ -57,27 +56,12 @@ class CreatorCode(ReconstructAble[Dict[str, Any], HTTPClientT]):
     account: :class:`fortnite_api.Account`
         The account associated with the creator code. Ie, the account
         that owns the creator code.
-    status: :class:`fortnite_api.CreatorCodeStatus`
-        The current status of the creator code.
-    verified: :class:`bool`
-        Whether the creator code is verified.
-
-        .. note::
-
-            From internal testing, this seems to be always ``False``.
     """
 
-    __slots__: Tuple[str, ...] = ("code", "account", "verified", "status")
+    __slots__: Tuple[str, ...] = ("code", "account")
 
     def __init__(self, *, data: Dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
         self.code: str = data["code"]
         self.account: Account[HTTPClientT] = Account(data=data["account"], http=http)
-        self.verified: bool = data["verified"]
-        self.status: CreatorCodeStatus = CreatorCodeStatus(data["status"].lower())
-
-    @property
-    def disabled(self) -> bool:
-        """:class:`bool`: Whether the creator code is disabled."""
-        return self.status is CreatorCodeStatus.DISABLED

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -39,7 +39,6 @@ __all__: Tuple[str, ...] = (
     'AccountType',
     'TimeWindow',
     'StatsImageType',
-    'CreatorCodeStatus',
     'CosmeticCompatibleMode',
     'BannerIntensity',
     'CustomGender',

--- a/fortnite_api/enums.py
+++ b/fortnite_api/enums.py
@@ -327,21 +327,6 @@ class StatsImageType(enum.Enum):
     NONE = 'none'
 
 
-class CreatorCodeStatus(enum.Enum):
-    """Represents the status of a creator code.
-
-    Attributes
-    ----------
-    ACTIVE
-        The creator code is active.
-    DISABLED
-        The creator code is disabled.
-    """
-
-    ACTIVE = 'active'
-    DISABLED = 'disabled'
-
-
 class CosmeticCompatibleMode(enum.Enum):
     """A class that represents the compatibility of a cosmetic :class:`fortnite_api.MaterialInstance` with other modes.
 

--- a/tests/test_async_methods.py
+++ b/tests/test_async_methods.py
@@ -116,10 +116,6 @@ async def test_async_creator_code(api_key: str):
     mock_account_payload = dict(id=TEST_ACCOUNT_ID, name=TEST_ACCOUNT_NAME)
     assert creator_code.account == fn_api.Account(data=mock_account_payload, http=HTTPClient())
 
-    assert creator_code.status is fn_api.CreatorCodeStatus.ACTIVE
-    assert creator_code.disabled is False
-    assert creator_code.verified is False
-
 
 @pytest.mark.asyncio
 async def test_async_fetch_playlist(api_key: str):

--- a/tests/test_sync_methods.py
+++ b/tests/test_sync_methods.py
@@ -124,6 +124,7 @@ def test_sync_creator_code(api_key: str):
     mock_account_payload = dict(id=TEST_ACCOUNT_ID, name=TEST_ACCOUNT_NAME)
     assert creator_code.account == fn_api.Account(data=mock_account_payload, http=SyncHTTPClient())
 
+
 def test_sync_fetch_playlist(api_key: str):
     with fn_api.SyncClient(api_key=api_key) as client:
         playlists = client.fetch_playlists()

--- a/tests/test_sync_methods.py
+++ b/tests/test_sync_methods.py
@@ -124,11 +124,6 @@ def test_sync_creator_code(api_key: str):
     mock_account_payload = dict(id=TEST_ACCOUNT_ID, name=TEST_ACCOUNT_NAME)
     assert creator_code.account == fn_api.Account(data=mock_account_payload, http=SyncHTTPClient())
 
-    assert creator_code.status is fn_api.CreatorCodeStatus.ACTIVE
-    assert creator_code.disabled is False
-    assert creator_code.verified is False
-
-
 def test_sync_fetch_playlist(api_key: str):
     with fn_api.SyncClient(api_key=api_key) as client:
         playlists = client.fetch_playlists()


### PR DESCRIPTION
## Summary

This pull request removes `CreatorCode.status` and `CreatorCode.disabled`, since they where always got a static value. Instead the documentation has been adjusted to vague identify a CreatorCode status. Additionally `CreatorCode.verified` has also been removed, since it seems deprecated within Epics API and no codes with another value than `False` have been found.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
