### PR TITLE
Drop Python 3.9 and add support for Python 3.14

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "pip" # Cache the pip packages to speed up the workflow
 
       - name: Install Dependencies and Package

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install Dependencies
         run: python -m pip install -U pip setuptools build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "pip" # Cache the pip packages to speed up the workflow
 
       - name: Install Dependencies and Package
@@ -45,10 +45,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "pip" # Cache the pip packages to speed up the workflow
 
       - name: Install Dependencies and Project
@@ -69,10 +69,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "pip" # Cache the pip packages to speed up the workflow
 
       - name: Install Dependencies and Project

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The library's focus is to provide a simple and easy-to-use interface to interact
 
 ## Installation
 
-Note that **Python 3.9 or higher is required.**
+Note that **Python 3.10 or higher is required.**
 
 ```sh
 # Linux/macOS

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,11 @@ Changelog
 v3.3.0
 -------
 
+Breaking Changes
+~~~~~~~~~~~~~~~~
+- Drop support for Python 3.9. The minimum supported Python version is now 3.10.
+
+
 Bug Fixes
 ~~~~~~~~~
 - Fixed an issue that caused :class:`fortnite_api.Asset.resize` to raise :class:`TypeError` instead of :class:`ValueError` when the given size isn't a power of 2.

--- a/docs/extensions/attribute_table.py
+++ b/docs/extensions/attribute_table.py
@@ -28,7 +28,7 @@ import importlib
 import inspect
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, ClassVar, NamedTuple, Optional
+from typing import TYPE_CHECKING, ClassVar, NamedTuple
 
 from docutils import nodes
 from sphinx import addnodes
@@ -207,7 +207,7 @@ def build_lookup_table(env: BuildEnvironment) -> dict[str, list[str]]:
 class TableElement(NamedTuple):
     fullname: str
     label: str
-    badge: Optional[attributetablebadge]
+    badge: attributetablebadge | None
 
 
 def process_attributetable(app: Sphinx, doctree: nodes.Node, fromdocname: str) -> None:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ To install the Fortnite-API Python library, you can use pip. Run the following c
 
 .. note::
 
-   Note that Python 3.9 and greater is required to use this library.
+   Note that Python 3.10 and greater is required to use this library.
 
 .. code-block:: bash
 

--- a/examples/discord_integration.py
+++ b/examples/discord_integration.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Optional
 
 import discord
 from discord.ext import commands
@@ -73,7 +72,7 @@ class FortniteCog(commands.Cog):
 
         # (3.1) The main AES key is marked as optional in the documentation, so we must
         # handle the case where it is None.
-        main_key: Optional[str] = aes.main_key
+        main_key: str | None = aes.main_key
 
         # (4) and send a message back to the user.
         if main_key is None:

--- a/fortnite_api/abc.py
+++ b/fortnite_api/abc.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Generic, TypeVar, Union
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from typing_extensions import Self
 
@@ -118,7 +118,7 @@ class ReconstructAble(Generic[DictT, HTTPClientT]):
     # still keeping the correct HTTPClient type.
 
     @classmethod
-    def from_dict(cls: type[Self], data: DictT, *, client: Union[Client, SyncClient]) -> Self:
+    def from_dict(cls: type[Self], data: DictT, *, client: Client | SyncClient) -> Self:
         """Reconstructs this class from a raw dictionary object. This is useful for when you
         store the raw data and want to reconstruct the object later on.
 

--- a/fortnite_api/aes.py
+++ b/fortnite_api/aes.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import dataclasses
 import re
 from collections.abc import Generator
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from .abc import ReconstructAble
 from .http import HTTPClientT
@@ -155,11 +155,11 @@ class Aes(ReconstructAble[dict[str, Any], HTTPClientT]):
     def __init__(self, *, data: dict[str, Any], http: HTTPClientT):
         super().__init__(data=data, http=http)
 
-        self.main_key: Optional[str] = data.get("mainKey")
+        self.main_key: str | None = data.get("mainKey")
         self.build: str = data["build"]
 
         # In the case that the API gives us an invalid version, we will set it to None
-        self.version: Optional[Version] = None
+        self.version: Version | None = None
         version_info = VERSION_REGEX.findall(self.build)
         if version_info and len(version_info[0]) == 2:
             major, minor = version_info[0]
@@ -240,7 +240,7 @@ class DynamicKey(ReconstructAble[dict[str, Any], HTTPClientT]):
     def __hash__(self) -> int:
         return hash((self.pak_filename, self.pak_guid, self.key))
 
-    def __eq__(self, o: Union[object, DynamicKey]) -> bool:
+    def __eq__(self, o: object | DynamicKey) -> bool:
         if not isinstance(o, DynamicKey):
             return False
 

--- a/fortnite_api/asset.py
+++ b/fortnite_api/asset.py
@@ -66,13 +66,13 @@ class Asset(Generic[HTTPClientT]):
 
     __slots__: tuple[str, ...] = ('_http', '_url', '_max_size', '_size')
 
-    def __init__(self, *, http: HTTPClientT, url: str, max_size: Optional[int] = MISSING, size: int = MISSING) -> None:
+    def __init__(self, *, http: HTTPClientT, url: str, max_size: int | None = MISSING, size: int = MISSING) -> None:
         self._http: HTTPClientT = http
         self._url: str = url
 
         # The maximum size of the asset, if any. If provided, the url's default size is the maximum size.
         # MISSING for not supported, None for no max size, int for max size.
-        self._max_size: Optional[int] = max_size
+        self._max_size: int | None = max_size
 
         # The current size of this asset. Will only be set if the asset was resized.
         self._size: int = size
@@ -112,7 +112,7 @@ class Asset(Generic[HTTPClientT]):
         return self._max_size is not MISSING
 
     @property
-    def max_size(self) -> Optional[int]:
+    def max_size(self) -> int | None:
         """
         Returns
         --------
@@ -161,7 +161,7 @@ class Asset(Generic[HTTPClientT]):
     @overload
     def read(self: Asset[SyncHTTPClient], /) -> bytes: ...
 
-    def read(self) -> Union[Coroutine[Any, Any, bytes], bytes]:
+    def read(self) -> Coroutine[Any, Any, bytes] | bytes:
         """|maybecoro|
 
         Retrieves the content of this asset as a :class:`bytes` object. This is only a coroutine if the client is

--- a/fortnite_api/asset.py
+++ b/fortnite_api/asset.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 from collections.abc import Coroutine
-from typing import TYPE_CHECKING, Any, Generic, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Generic, overload
 
 from typing_extensions import Self
 

--- a/fortnite_api/banner.py
+++ b/fortnite_api/banner.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from .abc import Hashable, ReconstructAble
 from .http import HTTPClientT
@@ -114,7 +114,7 @@ class Banner(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
         self.name: str = data["name"]
         self.dev_name: str = data["devName"]
         self.description: str = data["description"]
-        self.category: Optional[str] = data.get("category")
+        self.category: str | None = data.get("category")
         self.full_usage_rights: bool = data["fullUsageRights"]
 
         self.images: Images[HTTPClientT] = Images(data=data, http=http)

--- a/fortnite_api/client.py
+++ b/fortnite_api/client.py
@@ -27,12 +27,12 @@ from __future__ import annotations
 import datetime
 import functools
 import inspect
-from collections.abc import Coroutine
-from typing import Any, Callable, Literal, Optional, TypeVar, Union, cast, overload
+from collections.abc import Callable, Coroutine
+from typing import Any, Concatenate, Literal, TypeVar, cast, overload
 
 import aiohttp
 import requests
-from typing_extensions import Concatenate, ParamSpec, Self
+from typing_extensions import ParamSpec, Self
 
 from .aes import Aes
 from .all import CosmeticsAll
@@ -92,8 +92,8 @@ def beta_method(func: SyncFetchFunc[SyncClient_T, P, T]) -> SyncFetchFunc[SyncCl
 
 
 def beta_method(
-    func: Union[FetchFunc[Client_T, P, T], SyncFetchFunc[SyncClient_T, P, T]]
-) -> Union[FetchFunc[Client_T, P, T], SyncFetchFunc[SyncClient_T, P, T]]:
+    func: FetchFunc[Client_T, P, T] | SyncFetchFunc[SyncClient_T, P, T],
+) -> FetchFunc[Client_T, P, T] | SyncFetchFunc[SyncClient_T, P, T]:
     if inspect.iscoroutinefunction(func):
         # This is coroutine, so we need to wrap it in an async function
         @functools.wraps(func)
@@ -169,10 +169,10 @@ class Client:
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: str | None = None,
         *,
         default_language: GameLanguage = GameLanguage.ENGLISH,
-        session: Optional[aiohttp.ClientSession] = None,
+        session: aiohttp.ClientSession | None = None,
         beta: bool = False,
         response_flags: ResponseFlags = ResponseFlags.INCLUDE_NOTHING,
     ) -> None:
@@ -190,7 +190,7 @@ class Client:
     async def __aexit__(self, *args: Any) -> None:
         await self.http.close()
 
-    def _resolve_default_language_value(self, language: Optional[GameLanguage] = MISSING) -> Optional[str]:
+    def _resolve_default_language_value(self, language: GameLanguage | None = MISSING) -> str | None:
         if language is None:
             # This user has specifically passed None, so they want to omit
             # a language parameter completely.
@@ -199,7 +199,7 @@ class Client:
         lang = self.default_language if language is MISSING else language
         return lang.value
 
-    def _resolve_response_flags_value(self, flags: Optional[ResponseFlags] = MISSING) -> Optional[int]:
+    def _resolve_response_flags_value(self, flags: ResponseFlags | None = MISSING) -> int | None:
         if flags is None:
             # This user has specifically passed None, so they want to omit
             # a response flags parameter completely.
@@ -210,7 +210,7 @@ class Client:
 
     # COSMETICS
     async def fetch_cosmetics_all(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> CosmeticsAll:
         """|coro|
 
@@ -241,7 +241,7 @@ class Client:
         return CosmeticsAll(data=data, http=self.http)
 
     async def fetch_cosmetics_br(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[CosmeticBr]:
         """|coro|
 
@@ -275,7 +275,7 @@ class Client:
         )
 
     async def fetch_cosmetics_cars(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[CosmeticCar]:
         """|coro|
 
@@ -309,7 +309,7 @@ class Client:
         )
 
     async def fetch_cosmetics_instruments(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[CosmeticInstrument]:
         """|coro|
 
@@ -343,7 +343,7 @@ class Client:
         )
 
     async def fetch_cosmetics_lego_kits(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[CosmeticLegoKit]:
         """|coro|
 
@@ -377,7 +377,7 @@ class Client:
         )
 
     async def fetch_variants_lego(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[VariantLego]:
         """|coro|
 
@@ -412,7 +412,7 @@ class Client:
         )
 
     async def fetch_variants_beans(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[VariantBean]:
         """|coro|
 
@@ -448,7 +448,7 @@ class Client:
         )
 
     async def fetch_cosmetics_tracks(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[CosmeticTrack]:
         """|coro|
 
@@ -487,8 +487,8 @@ class Client:
         /,
         cosmetic_id: str,
         *,
-        language: Optional[GameLanguage] = MISSING,
-        response_flags: Optional[ResponseFlags] = MISSING,
+        language: GameLanguage | None = MISSING,
+        response_flags: ResponseFlags | None = MISSING,
     ) -> CosmeticBr:
         """|coro|
 
@@ -529,7 +529,7 @@ class Client:
     # NEW COSMETICS
 
     async def fetch_cosmetics_new(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> NewCosmetics:
         """|coro|
 
@@ -564,40 +564,40 @@ class Client:
         self,
         *,
         multiple: Literal[True] = True,
-        language: Optional[GameLanguage] = MISSING,
-        response_flags: Optional[ResponseFlags] = MISSING,
+        language: GameLanguage | None = MISSING,
+        response_flags: ResponseFlags | None = MISSING,
         search_language: GameLanguage = GameLanguage.ENGLISH,
         match_method: MatchMethod = MatchMethod.FULL,
-        id: Optional[str] = ...,
-        name: Optional[str] = ...,
-        description: Optional[str] = ...,
-        type: Optional[CosmeticType] = ...,
-        type_display: Optional[str] = ...,
-        type_backend: Optional[str] = ...,
-        rarity: Optional[CosmeticRarity] = ...,
-        rarity_display: Optional[str] = ...,
-        rarity_backend: Optional[str] = ...,
-        has_series: Optional[bool] = ...,
-        series: Optional[str] = ...,
-        series_backend: Optional[str] = ...,
-        has_set: Optional[bool] = ...,
-        set: Optional[str] = ...,
-        set_text: Optional[str] = ...,
-        set_backend: Optional[str] = ...,
-        has_introduction: Optional[bool] = ...,
-        introduction_backend: Optional[str] = ...,
-        introduction_chapter: Optional[str] = ...,
-        introduction_season: Optional[str] = ...,
-        has_featured_image: Optional[bool] = ...,
-        has_variants: Optional[bool] = ...,
-        gameplay_tag: Optional[str] = ...,
-        has_meta_tags: Optional[bool] = ...,
-        has_dynamic_pak_id: Optional[bool] = ...,
-        dynamic_pak_id: Optional[str] = ...,
-        added: Optional[datetime.datetime] = ...,
-        added_since: Optional[datetime.datetime] = ...,
-        unseen_for: Optional[int] = ...,
-        last_appearance: Optional[datetime.datetime] = ...,
+        id: str | None = ...,
+        name: str | None = ...,
+        description: str | None = ...,
+        type: CosmeticType | None = ...,
+        type_display: str | None = ...,
+        type_backend: str | None = ...,
+        rarity: CosmeticRarity | None = ...,
+        rarity_display: str | None = ...,
+        rarity_backend: str | None = ...,
+        has_series: bool | None = ...,
+        series: str | None = ...,
+        series_backend: str | None = ...,
+        has_set: bool | None = ...,
+        set: str | None = ...,
+        set_text: str | None = ...,
+        set_backend: str | None = ...,
+        has_introduction: bool | None = ...,
+        introduction_backend: str | None = ...,
+        introduction_chapter: str | None = ...,
+        introduction_season: str | None = ...,
+        has_featured_image: bool | None = ...,
+        has_variants: bool | None = ...,
+        gameplay_tag: str | None = ...,
+        has_meta_tags: bool | None = ...,
+        has_dynamic_pak_id: bool | None = ...,
+        dynamic_pak_id: str | None = ...,
+        added: datetime.datetime | None = ...,
+        added_since: datetime.datetime | None = ...,
+        unseen_for: int | None = ...,
+        last_appearance: datetime.datetime | None = ...,
     ) -> list[CosmeticBr]: ...
 
     @overload
@@ -605,43 +605,43 @@ class Client:
         self,
         *,
         multiple: Literal[False] = False,
-        language: Optional[GameLanguage] = MISSING,
-        response_flags: Optional[ResponseFlags] = MISSING,
-        search_language: Optional[GameLanguage] = MISSING,
+        language: GameLanguage | None = MISSING,
+        response_flags: ResponseFlags | None = MISSING,
+        search_language: GameLanguage | None = MISSING,
         match_method: MatchMethod = MatchMethod.FULL,
-        id: Optional[str] = ...,
-        name: Optional[str] = ...,
-        description: Optional[str] = ...,
-        type: Optional[CosmeticType] = ...,
-        type_display: Optional[str] = ...,
-        type_backend: Optional[str] = ...,
-        rarity: Optional[CosmeticRarity] = ...,
-        rarity_display: Optional[str] = ...,
-        rarity_backend: Optional[str] = ...,
-        has_series: Optional[bool] = ...,
-        series: Optional[str] = ...,
-        series_backend: Optional[str] = ...,
-        has_set: Optional[bool] = ...,
-        set: Optional[str] = ...,
-        set_text: Optional[str] = ...,
-        set_backend: Optional[str] = ...,
-        has_introduction: Optional[bool] = ...,
-        introduction_backend: Optional[str] = ...,
-        introduction_chapter: Optional[str] = ...,
-        introduction_season: Optional[str] = ...,
-        has_featured_image: Optional[bool] = ...,
-        has_variants: Optional[bool] = ...,
-        gameplay_tag: Optional[str] = ...,
-        has_meta_tags: Optional[bool] = ...,
-        has_dynamic_pak_id: Optional[bool] = ...,
-        dynamic_pak_id: Optional[str] = ...,
-        added: Optional[datetime.datetime] = ...,
-        added_since: Optional[datetime.datetime] = ...,
-        unseen_for: Optional[int] = ...,
-        last_appearance: Optional[datetime.datetime] = ...,
+        id: str | None = ...,
+        name: str | None = ...,
+        description: str | None = ...,
+        type: CosmeticType | None = ...,
+        type_display: str | None = ...,
+        type_backend: str | None = ...,
+        rarity: CosmeticRarity | None = ...,
+        rarity_display: str | None = ...,
+        rarity_backend: str | None = ...,
+        has_series: bool | None = ...,
+        series: str | None = ...,
+        series_backend: str | None = ...,
+        has_set: bool | None = ...,
+        set: str | None = ...,
+        set_text: str | None = ...,
+        set_backend: str | None = ...,
+        has_introduction: bool | None = ...,
+        introduction_backend: str | None = ...,
+        introduction_chapter: str | None = ...,
+        introduction_season: str | None = ...,
+        has_featured_image: bool | None = ...,
+        has_variants: bool | None = ...,
+        gameplay_tag: str | None = ...,
+        has_meta_tags: bool | None = ...,
+        has_dynamic_pak_id: bool | None = ...,
+        dynamic_pak_id: str | None = ...,
+        added: datetime.datetime | None = ...,
+        added_since: datetime.datetime | None = ...,
+        unseen_for: int | None = ...,
+        last_appearance: datetime.datetime | None = ...,
     ) -> CosmeticBr: ...
 
-    async def search_br_cosmetics(self, **kwargs: Any) -> Union[CosmeticBr, list[CosmeticBr]]:
+    async def search_br_cosmetics(self, **kwargs: Any) -> CosmeticBr | list[CosmeticBr]:
         """|coro|
 
         Searches all Battle Royale cosmetics available in Fortnite and returns
@@ -775,7 +775,7 @@ class Client:
         return Aes(data=data, http=self.http)
 
     # BANNERS
-    async def fetch_banners(self, *, language: Optional[GameLanguage] = MISSING) -> list[Banner]:
+    async def fetch_banners(self, *, language: GameLanguage | None = MISSING) -> list[Banner]:
         """|coro|
 
         Fetch all banners available in Fortnite.
@@ -842,7 +842,7 @@ class Client:
 
     # MAPS
 
-    async def fetch_map(self, *, language: Optional[GameLanguage] = MISSING) -> Map:
+    async def fetch_map(self, *, language: GameLanguage | None = MISSING) -> Map:
         """|coro|
 
         Fetches the current map of Fortnite.
@@ -865,7 +865,7 @@ class Client:
 
     # NEWS
 
-    async def fetch_news(self, *, language: Optional[GameLanguage] = MISSING) -> News:
+    async def fetch_news(self, *, language: GameLanguage | None = MISSING) -> News:
         """|coro|
 
         Fetch the news for Fortnite. This includes all news for all game modes.
@@ -886,7 +886,7 @@ class Client:
         data = await self.http.get_news(language=self._resolve_default_language_value(language))
         return News(data=data, http=self.http)
 
-    async def fetch_news_br(self, *, language: Optional[GameLanguage] = MISSING) -> GameModeNews:
+    async def fetch_news_br(self, *, language: GameLanguage | None = MISSING) -> GameModeNews:
         """|coro|
 
         Fetches the current Battle Royale news.
@@ -912,7 +912,7 @@ class Client:
         data = await self.http.get_news_br(language=self._resolve_default_language_value(language))
         return GameModeNews(data=data, http=self.http)
 
-    async def fetch_news_stw(self, *, language: Optional[GameLanguage] = MISSING) -> GameModeNews:
+    async def fetch_news_stw(self, *, language: GameLanguage | None = MISSING) -> GameModeNews:
         """|coro|
 
         Fetches the current Save the World news.
@@ -940,7 +940,7 @@ class Client:
 
     # PLAYLISTS
 
-    async def fetch_playlists(self, /, *, language: Optional[GameLanguage] = MISSING) -> list[Playlist]:
+    async def fetch_playlists(self, /, *, language: GameLanguage | None = MISSING) -> list[Playlist]:
         """|coro|
 
         Fetches a list of current playlists available in Fortnite.
@@ -964,7 +964,7 @@ class Client:
             lambda x: Playlist(data=x, http=self.http),
         )
 
-    async def fetch_playlist(self, id: str, /, *, language: Optional[GameLanguage] = MISSING) -> Playlist:
+    async def fetch_playlist(self, id: str, /, *, language: GameLanguage | None = MISSING) -> Playlist:
         """|coro|
 
         Fetch a specific playlist by its ID.
@@ -997,8 +997,8 @@ class Client:
     async def fetch_br_stats(
         self,
         *,
-        name: Optional[str] = None,
-        account_id: Optional[str] = None,
+        name: str | None = None,
+        account_id: str | None = None,
         type: AccountType = AccountType.EPIC,
         time_window: TimeWindow = TimeWindow.LIFETIME,
         image: StatsImageType = StatsImageType.NONE,
@@ -1071,7 +1071,7 @@ class Client:
 
     # SHOP
     async def fetch_shop(
-        self, /, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, /, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> Shop:
         """|coro|
 
@@ -1247,10 +1247,10 @@ class SyncClient:
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: str | None = None,
         *,
         default_language: GameLanguage = GameLanguage.ENGLISH,
-        session: Optional[requests.Session] = None,
+        session: requests.Session | None = None,
         beta: bool = False,
         response_flags: ResponseFlags = ResponseFlags.INCLUDE_NOTHING,
     ) -> None:
@@ -1269,7 +1269,7 @@ class SyncClient:
     def __exit__(self, *args: Any) -> None:
         self.http.close()
 
-    def _resolve_default_language_value(self, language: Optional[GameLanguage] = MISSING) -> Optional[str]:
+    def _resolve_default_language_value(self, language: GameLanguage | None = MISSING) -> str | None:
         if language is None:
             # This user has specifically passed None, so they want to omit
             # a language parameter completely.
@@ -1278,7 +1278,7 @@ class SyncClient:
         lang = self.default_language if language is MISSING else language
         return lang.value
 
-    def _resolve_response_flags_value(self, flags: Optional[ResponseFlags] = MISSING) -> Optional[int]:
+    def _resolve_response_flags_value(self, flags: ResponseFlags | None = MISSING) -> int | None:
         if flags is None:
             # This user has specifically passed None, so they want to omit
             # a response flags parameter completely.
@@ -1290,7 +1290,7 @@ class SyncClient:
     # COSMETICS
     @copy_doc(Client.fetch_cosmetics_all)
     def fetch_cosmetics_all(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> CosmeticsAll[SyncHTTPClient]:
         data = self.http.get_cosmetics_all(
             language=self._resolve_default_language_value(language),
@@ -1300,7 +1300,7 @@ class SyncClient:
 
     @copy_doc(Client.fetch_cosmetics_br)
     def fetch_cosmetics_br(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[CosmeticBr[SyncHTTPClient]]:
         data = self.http.get_cosmetics_br(
             language=self._resolve_default_language_value(language),
@@ -1313,7 +1313,7 @@ class SyncClient:
 
     @copy_doc(Client.fetch_cosmetics_cars)
     def fetch_cosmetics_cars(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[CosmeticCar[SyncHTTPClient]]:
         data = self.http.get_cosmetics_cars(
             language=self._resolve_default_language_value(language),
@@ -1326,7 +1326,7 @@ class SyncClient:
 
     @copy_doc(Client.fetch_cosmetics_instruments)
     def fetch_cosmetics_instruments(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[CosmeticInstrument[SyncHTTPClient]]:
         data = self.http.get_cosmetics_instruments(
             language=self._resolve_default_language_value(language),
@@ -1339,7 +1339,7 @@ class SyncClient:
 
     @copy_doc(Client.fetch_cosmetics_lego_kits)
     def fetch_cosmetics_lego_kits(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[CosmeticLegoKit[SyncHTTPClient]]:
         data = self.http.get_cosmetics_lego_kits(
             language=self._resolve_default_language_value(language),
@@ -1352,7 +1352,7 @@ class SyncClient:
 
     @copy_doc(Client.fetch_variants_lego)
     def fetch_variants_lego(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[VariantLego[SyncHTTPClient]]:
         data = self.http.get_cosmetics_lego(
             language=self._resolve_default_language_value(language),
@@ -1365,7 +1365,7 @@ class SyncClient:
 
     @copy_doc(Client.fetch_variants_beans)
     def fetch_variants_beans(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[VariantBean[SyncHTTPClient]]:
         data = self.http.get_cosmetics_beans(
             language=self._resolve_default_language_value(language),
@@ -1378,7 +1378,7 @@ class SyncClient:
 
     @copy_doc(Client.fetch_cosmetics_tracks)
     def fetch_cosmetics_tracks(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> list[CosmeticTrack[SyncHTTPClient]]:
         data = self.http.get_cosmetics_tracks(
             language=self._resolve_default_language_value(language),
@@ -1395,8 +1395,8 @@ class SyncClient:
         /,
         cosmetic_id: str,
         *,
-        language: Optional[GameLanguage] = MISSING,
-        response_flags: Optional[ResponseFlags] = MISSING,
+        language: GameLanguage | None = MISSING,
+        response_flags: ResponseFlags | None = MISSING,
     ) -> CosmeticBr[SyncHTTPClient]:
         data = self.http.get_cosmetic_br(
             cosmetic_id,
@@ -1409,7 +1409,7 @@ class SyncClient:
 
     @copy_doc(Client.fetch_cosmetics_new)
     def fetch_cosmetics_new(
-        self, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> NewCosmetics[SyncHTTPClient]:
         data = self.http.get_cosmetics_new(
             language=self._resolve_default_language_value(language),
@@ -1422,40 +1422,40 @@ class SyncClient:
         self,
         *,
         multiple: Literal[True] = True,
-        language: Optional[GameLanguage] = MISSING,
-        response_flags: Optional[ResponseFlags] = MISSING,
+        language: GameLanguage | None = MISSING,
+        response_flags: ResponseFlags | None = MISSING,
         search_language: GameLanguage = GameLanguage.ENGLISH,
         match_method: MatchMethod = MatchMethod.FULL,
-        id: Optional[str] = ...,
-        name: Optional[str] = ...,
-        description: Optional[str] = ...,
-        type: Optional[CosmeticType] = ...,
-        type_display: Optional[str] = ...,
-        type_backend: Optional[str] = ...,
-        rarity: Optional[CosmeticRarity] = ...,
-        rarity_display: Optional[str] = ...,
-        rarity_backend: Optional[str] = ...,
-        has_series: Optional[bool] = ...,
-        series: Optional[str] = ...,
-        series_backend: Optional[str] = ...,
-        has_set: Optional[bool] = ...,
-        set: Optional[str] = ...,
-        set_text: Optional[str] = ...,
-        set_backend: Optional[str] = ...,
-        has_introduction: Optional[bool] = ...,
-        introduction_backend: Optional[str] = ...,
-        introduction_chapter: Optional[str] = ...,
-        introduction_season: Optional[str] = ...,
-        has_featured_image: Optional[bool] = ...,
-        has_variants: Optional[bool] = ...,
-        gameplay_tag: Optional[str] = ...,
-        has_meta_tags: Optional[bool] = ...,
-        has_dynamic_pak_id: Optional[bool] = ...,
-        dynamic_pak_id: Optional[str] = ...,
-        added: Optional[datetime.datetime] = ...,
-        added_since: Optional[datetime.datetime] = ...,
-        unseen_for: Optional[int] = ...,
-        last_appearance: Optional[datetime.datetime] = ...,
+        id: str | None = ...,
+        name: str | None = ...,
+        description: str | None = ...,
+        type: CosmeticType | None = ...,
+        type_display: str | None = ...,
+        type_backend: str | None = ...,
+        rarity: CosmeticRarity | None = ...,
+        rarity_display: str | None = ...,
+        rarity_backend: str | None = ...,
+        has_series: bool | None = ...,
+        series: str | None = ...,
+        series_backend: str | None = ...,
+        has_set: bool | None = ...,
+        set: str | None = ...,
+        set_text: str | None = ...,
+        set_backend: str | None = ...,
+        has_introduction: bool | None = ...,
+        introduction_backend: str | None = ...,
+        introduction_chapter: str | None = ...,
+        introduction_season: str | None = ...,
+        has_featured_image: bool | None = ...,
+        has_variants: bool | None = ...,
+        gameplay_tag: str | None = ...,
+        has_meta_tags: bool | None = ...,
+        has_dynamic_pak_id: bool | None = ...,
+        dynamic_pak_id: str | None = ...,
+        added: datetime.datetime | None = ...,
+        added_since: datetime.datetime | None = ...,
+        unseen_for: int | None = ...,
+        last_appearance: datetime.datetime | None = ...,
     ) -> list[CosmeticBr[SyncHTTPClient]]: ...
 
     @overload
@@ -1463,44 +1463,44 @@ class SyncClient:
         self,
         *,
         multiple: Literal[False] = False,
-        language: Optional[GameLanguage] = MISSING,
-        response_flags: Optional[ResponseFlags] = MISSING,
-        search_language: Optional[GameLanguage] = MISSING,
+        language: GameLanguage | None = MISSING,
+        response_flags: ResponseFlags | None = MISSING,
+        search_language: GameLanguage | None = MISSING,
         match_method: MatchMethod = MatchMethod.FULL,
-        id: Optional[str] = ...,
-        name: Optional[str] = ...,
-        description: Optional[str] = ...,
-        type: Optional[CosmeticType] = ...,
-        type_display: Optional[str] = ...,
-        type_backend: Optional[str] = ...,
-        rarity: Optional[CosmeticRarity] = ...,
-        rarity_display: Optional[str] = ...,
-        rarity_backend: Optional[str] = ...,
-        has_series: Optional[bool] = ...,
-        series: Optional[str] = ...,
-        series_backend: Optional[str] = ...,
-        has_set: Optional[bool] = ...,
-        set: Optional[str] = ...,
-        set_text: Optional[str] = ...,
-        set_backend: Optional[str] = ...,
-        has_introduction: Optional[bool] = ...,
-        introduction_backend: Optional[str] = ...,
-        introduction_chapter: Optional[str] = ...,
-        introduction_season: Optional[str] = ...,
-        has_featured_image: Optional[bool] = ...,
-        has_variants: Optional[bool] = ...,
-        gameplay_tag: Optional[str] = ...,
-        has_meta_tags: Optional[bool] = ...,
-        has_dynamic_pak_id: Optional[bool] = ...,
-        dynamic_pak_id: Optional[str] = ...,
-        added: Optional[datetime.datetime] = ...,
-        added_since: Optional[datetime.datetime] = ...,
-        unseen_for: Optional[int] = ...,
-        last_appearance: Optional[datetime.datetime] = ...,
+        id: str | None = ...,
+        name: str | None = ...,
+        description: str | None = ...,
+        type: CosmeticType | None = ...,
+        type_display: str | None = ...,
+        type_backend: str | None = ...,
+        rarity: CosmeticRarity | None = ...,
+        rarity_display: str | None = ...,
+        rarity_backend: str | None = ...,
+        has_series: bool | None = ...,
+        series: str | None = ...,
+        series_backend: str | None = ...,
+        has_set: bool | None = ...,
+        set: str | None = ...,
+        set_text: str | None = ...,
+        set_backend: str | None = ...,
+        has_introduction: bool | None = ...,
+        introduction_backend: str | None = ...,
+        introduction_chapter: str | None = ...,
+        introduction_season: str | None = ...,
+        has_featured_image: bool | None = ...,
+        has_variants: bool | None = ...,
+        gameplay_tag: str | None = ...,
+        has_meta_tags: bool | None = ...,
+        has_dynamic_pak_id: bool | None = ...,
+        dynamic_pak_id: str | None = ...,
+        added: datetime.datetime | None = ...,
+        added_since: datetime.datetime | None = ...,
+        unseen_for: int | None = ...,
+        last_appearance: datetime.datetime | None = ...,
     ) -> CosmeticBr[SyncHTTPClient]: ...
 
     @copy_doc(Client.search_br_cosmetics)
-    def search_br_cosmetics(self, **kwargs: Any) -> Union[CosmeticBr[SyncHTTPClient], list[CosmeticBr[SyncHTTPClient]]]:
+    def search_br_cosmetics(self, **kwargs: Any) -> CosmeticBr[SyncHTTPClient] | list[CosmeticBr[SyncHTTPClient]]:
         multiple = kwargs.pop('multiple', False)
 
         kwargs['language'] = self._resolve_default_language_value(kwargs.pop('language', MISSING))
@@ -1531,7 +1531,7 @@ class SyncClient:
 
     # BANNERS
     @copy_doc(Client.fetch_banners)
-    def fetch_banners(self, *, language: Optional[GameLanguage] = MISSING) -> list[Banner[SyncHTTPClient]]:
+    def fetch_banners(self, *, language: GameLanguage | None = MISSING) -> list[Banner[SyncHTTPClient]]:
         data = self.http.get_banners(language=self._resolve_default_language_value(language))
         return TransformerListProxy(
             data,
@@ -1556,31 +1556,31 @@ class SyncClient:
     # MAPS
 
     @copy_doc(Client.fetch_map)
-    def fetch_map(self, *, language: Optional[GameLanguage] = MISSING) -> Map[SyncHTTPClient]:
+    def fetch_map(self, *, language: GameLanguage | None = MISSING) -> Map[SyncHTTPClient]:
         data = self.http.get_map(language=self._resolve_default_language_value(language))
         return Map(data=data, http=self.http)
 
     # NEWS
 
     @copy_doc(Client.fetch_news)
-    def fetch_news(self, *, language: Optional[GameLanguage] = MISSING) -> News[SyncHTTPClient]:
+    def fetch_news(self, *, language: GameLanguage | None = MISSING) -> News[SyncHTTPClient]:
         data = self.http.get_news(language=self._resolve_default_language_value(language))
         return News(data=data, http=self.http)
 
     @copy_doc(Client.fetch_news_br)
-    def fetch_news_br(self, *, language: Optional[GameLanguage] = MISSING) -> GameModeNews[SyncHTTPClient]:
+    def fetch_news_br(self, *, language: GameLanguage | None = MISSING) -> GameModeNews[SyncHTTPClient]:
         data = self.http.get_news_br(language=self._resolve_default_language_value(language))
         return GameModeNews(data=data, http=self.http)
 
     @copy_doc(Client.fetch_news_stw)
-    def fetch_news_stw(self, *, language: Optional[GameLanguage] = MISSING) -> GameModeNews[SyncHTTPClient]:
+    def fetch_news_stw(self, *, language: GameLanguage | None = MISSING) -> GameModeNews[SyncHTTPClient]:
         data = self.http.get_news_stw(language=self._resolve_default_language_value(language))
         return GameModeNews(data=data, http=self.http)
 
     # PLAYLISTS
 
     @copy_doc(Client.fetch_playlists)
-    def fetch_playlists(self, /, *, language: Optional[GameLanguage] = MISSING) -> list[Playlist[SyncHTTPClient]]:
+    def fetch_playlists(self, /, *, language: GameLanguage | None = MISSING) -> list[Playlist[SyncHTTPClient]]:
         data = self.http.get_playlists(language=self._resolve_default_language_value(language))
         return TransformerListProxy(
             data,
@@ -1588,7 +1588,7 @@ class SyncClient:
         )
 
     @copy_doc(Client.fetch_playlist)
-    def fetch_playlist(self, id: str, /, *, language: Optional[GameLanguage] = MISSING) -> Playlist[SyncHTTPClient]:
+    def fetch_playlist(self, id: str, /, *, language: GameLanguage | None = MISSING) -> Playlist[SyncHTTPClient]:
         data = self.http.get_playlist(id, language=self._resolve_default_language_value(language))
         return Playlist(data=data, http=self.http)
 
@@ -1598,8 +1598,8 @@ class SyncClient:
     def fetch_br_stats(
         self,
         *,
-        name: Optional[str] = None,
-        account_id: Optional[str] = None,
+        name: str | None = None,
+        account_id: str | None = None,
         type: AccountType = AccountType.EPIC,
         time_window: TimeWindow = TimeWindow.LIFETIME,
         image: StatsImageType = StatsImageType.NONE,
@@ -1646,7 +1646,7 @@ class SyncClient:
 
     @copy_doc(Client.fetch_shop)
     def fetch_shop(
-        self, /, *, language: Optional[GameLanguage] = MISSING, response_flags: Optional[ResponseFlags] = MISSING
+        self, /, *, language: GameLanguage | None = MISSING, response_flags: ResponseFlags | None = MISSING
     ) -> Shop[SyncHTTPClient]:
         data = self.http.get_shop(
             language=self._resolve_default_language_value(language),

--- a/fortnite_api/cosmetics/br.py
+++ b/fortnite_api/cosmetics/br.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Optional
+from typing import Any
 
 from ..abc import ReconstructAble
 from ..asset import Asset
@@ -71,7 +71,7 @@ class CosmeticBrSet(ReconstructAble[dict[str, Any], HTTPClientT]):
     def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
-        self.value: Optional[str] = data.get('value')
+        self.value: str | None = data.get('value')
         self.text: str = data['text']
         self.backend_value: str = data['backendValue']
 
@@ -144,8 +144,8 @@ class CosmeticBrVariantOption(ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         self.tag: str = data['tag']
-        self.name: Optional[str] = data.get('name')
-        self.unlock_requirements: Optional[str] = data.get('unlockRequirements')
+        self.name: str | None = data.get('name')
+        self.unlock_requirements: str | None = data.get('unlockRequirements')
         self.image: Asset[HTTPClientT] = Asset(http=http, url=data['image'])
 
 
@@ -179,7 +179,7 @@ class CosmeticBrVariant(ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         self.channel: str = data['channel']
-        self.type: Optional[str] = data.get('type')
+        self.type: str | None = data.get('type')
 
         self.options: list[CosmeticBrVariantOption[HTTPClientT]] = [
             CosmeticBrVariantOption(data=option, http=http) for option in data['options']
@@ -299,29 +299,29 @@ class CosmeticBr(Cosmetic[dict[str, Any], HTTPClientT]):
 
         self.name: str = data['name']
         self.description: str = data['description']
-        self.exclusive_description: Optional[str] = data.get('exclusiveDescription')
-        self.unlock_requirements: Optional[str] = data.get('unlockRequirements')
-        self.custom_exclusive_callout: Optional[str] = data.get('customExclusiveCallout')
+        self.exclusive_description: str | None = data.get('exclusiveDescription')
+        self.unlock_requirements: str | None = data.get('unlockRequirements')
+        self.custom_exclusive_callout: str | None = data.get('customExclusiveCallout')
 
         _type = data.get('type')
-        self.type: Optional[CosmeticTypeInfo[HTTPClientT]] = _type and CosmeticTypeInfo(data=_type, http=http)
+        self.type: CosmeticTypeInfo[HTTPClientT] | None = _type and CosmeticTypeInfo(data=_type, http=http)
 
         rarity = data.get('rarity')
-        self.rarity: Optional[CosmeticRarityInfo[HTTPClientT]] = rarity and CosmeticRarityInfo(data=rarity, http=http)
+        self.rarity: CosmeticRarityInfo[HTTPClientT] | None = rarity and CosmeticRarityInfo(data=rarity, http=http)
 
         series = data.get('series')
-        self.series: Optional[CosmeticSeriesInfo[HTTPClientT]] = series and CosmeticSeriesInfo(http=http, data=series)
+        self.series: CosmeticSeriesInfo[HTTPClientT] | None = series and CosmeticSeriesInfo(http=http, data=series)
 
         _set = data.get('set')
-        self.set: Optional[CosmeticBrSet[HTTPClientT]] = _set and CosmeticBrSet(data=_set, http=http)
+        self.set: CosmeticBrSet[HTTPClientT] | None = _set and CosmeticBrSet(data=_set, http=http)
 
         introduction = data.get('introduction')
-        self.introduction: Optional[CosmeticBrIntroduction[HTTPClientT]] = introduction and CosmeticBrIntroduction(
+        self.introduction: CosmeticBrIntroduction[HTTPClientT] | None = introduction and CosmeticBrIntroduction(
             data=introduction, http=http
         )
 
         images = data.get('images')
-        self.images: Optional[CosmeticImages[HTTPClientT]] = images and CosmeticImages(http=http, data=images)
+        self.images: CosmeticImages[HTTPClientT] | None = images and CosmeticImages(http=http, data=images)
 
         variants: list[dict[str, Any]] = get_with_fallback(data, 'variants', list)
         self.variants: list[CosmeticBrVariant[HTTPClientT]] = [
@@ -336,19 +336,19 @@ class CosmeticBr(Cosmetic[dict[str, Any], HTTPClientT]):
         self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplayTags', list)
         self.meta_tags: list[str] = get_with_fallback(data, 'metaTags', list)
 
-        self.showcase_video_id: Optional[str] = data.get('showcaseVideo')
-        self.dynamic_pak_id: Optional[str] = data.get('dynamicPakId')
-        self.item_preview_hero_path: Optional[str] = data.get('itemPreviewHeroPath')
-        self.display_asset_path: Optional[str] = data.get('displayAssetPath')
-        self.definition_path: Optional[str] = data.get('definitionPath')
-        self.path: Optional[str] = data.get('path')
+        self.showcase_video_id: str | None = data.get('showcaseVideo')
+        self.dynamic_pak_id: str | None = data.get('dynamicPakId')
+        self.item_preview_hero_path: str | None = data.get('itemPreviewHeroPath')
+        self.display_asset_path: str | None = data.get('displayAssetPath')
+        self.definition_path: str | None = data.get('definitionPath')
+        self.path: str | None = data.get('path')
 
         self.shop_history: list[datetime.datetime] = [
             parse_time(time) for time in get_with_fallback(data, 'shopHistory', list)
         ]
 
     @property
-    def showcase_video_url(self) -> Optional[str]:
+    def showcase_video_url(self) -> str | None:
         """Optional[:class:`str`]: The URL of the YouTube showcase video of the cosmetic, if any."""
         _id = self.showcase_video_id
         if not _id:

--- a/fortnite_api/cosmetics/car.py
+++ b/fortnite_api/cosmetics/car.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Optional
+from typing import Any
 
 from ..http import HTTPClientT
 from ..utils import get_with_fallback, parse_time, simple_repr
@@ -103,29 +103,27 @@ class CosmeticCar(Cosmetic[dict[str, Any], HTTPClientT]):
         self.description: str = data['description']
 
         _type = data.get('type')
-        self.type: Optional[CosmeticTypeInfo[HTTPClientT]] = _type and CosmeticTypeInfo(data=_type, http=http)
+        self.type: CosmeticTypeInfo[HTTPClientT] | None = _type and CosmeticTypeInfo(data=_type, http=http)
 
         _rarity = data.get('rarity')
-        self.rarity: Optional[CosmeticRarityInfo[HTTPClientT]] = _rarity and CosmeticRarityInfo(data=_rarity, http=http)
+        self.rarity: CosmeticRarityInfo[HTTPClientT] | None = _rarity and CosmeticRarityInfo(data=_rarity, http=http)
 
         _images = data.get('images')
-        self.images: Optional[CosmeticImages[HTTPClientT]] = _images and CosmeticImages(data=_images, http=self._http)
+        self.images: CosmeticImages[HTTPClientT] | None = _images and CosmeticImages(data=_images, http=self._http)
 
         _series = data.get('series')
-        self.series: Optional[CosmeticSeriesInfo[HTTPClientT]] = _series and CosmeticSeriesInfo(
-            data=_series, http=self._http
-        )
+        self.series: CosmeticSeriesInfo[HTTPClientT] | None = _series and CosmeticSeriesInfo(data=_series, http=self._http)
 
         self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplayTags', list)
-        self.path: Optional[str] = data.get('path')
-        self.showcase_video_id: Optional[str] = data.get('showcaseVideo')
+        self.path: str | None = data.get('path')
+        self.showcase_video_id: str | None = data.get('showcaseVideo')
 
         self.shop_history: list[datetime.datetime] = [
             parse_time(time) for time in get_with_fallback(data, 'shopHistory', list)
         ]
 
     @property
-    def showcase_video_url(self) -> Optional[str]:
+    def showcase_video_url(self) -> str | None:
         """Optional[:class:`str`]: The URL of the YouTube showcase video of the cosmetic, if any."""
         _id = self.showcase_video_id
         if not _id:

--- a/fortnite_api/cosmetics/common.py
+++ b/fortnite_api/cosmetics/common.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, TypeVar
 
 from ..abc import DictT, Hashable, ReconstructAble
 from ..asset import Asset
@@ -207,7 +207,7 @@ class CosmeticSeriesInfo(ReconstructAble[dict[str, Any], HTTPClientT]):
         self.backend_value: str = data["backendValue"]
 
         image = data.get("image")
-        self.image: Optional[Asset[HTTPClientT]] = image and Asset(http=http, url=image)
+        self.image: Asset[HTTPClientT] | None = image and Asset(http=http, url=image)
 
         self.colors: list[str] = get_with_fallback(data, "colors", list)
 
@@ -267,28 +267,28 @@ class CosmeticImages(Images[HTTPClientT]):
         super().__init__(data=data, http=http)
 
         featured = data.get("featured")
-        self.featured: Optional[Asset[HTTPClientT]] = featured and Asset(http=http, url=featured)
+        self.featured: Asset[HTTPClientT] | None = featured and Asset(http=http, url=featured)
 
         lego = data.get("lego")
-        self.lego: Optional[Asset[HTTPClientT]] = lego and Asset(http=http, url=lego)
+        self.lego: Asset[HTTPClientT] | None = lego and Asset(http=http, url=lego)
 
         bean = data.get("bean")
-        self.bean: Optional[Asset[HTTPClientT]] = bean and Asset(http=http, url=bean)
+        self.bean: Asset[HTTPClientT] | None = bean and Asset(http=http, url=bean)
 
         small = data.get("small")
-        self.small: Optional[Asset[HTTPClientT]] = small and Asset(http=http, url=small)
+        self.small: Asset[HTTPClientT] | None = small and Asset(http=http, url=small)
 
         large = data.get("large")
-        self.large: Optional[Asset[HTTPClientT]] = large and Asset(http=http, url=large)
+        self.large: Asset[HTTPClientT] | None = large and Asset(http=http, url=large)
 
         wide = data.get("wide")
-        self.wide: Optional[Asset[HTTPClientT]] = wide and Asset(http=http, url=wide)
+        self.wide: Asset[HTTPClientT] | None = wide and Asset(http=http, url=wide)
 
         self._other: dict[str, str] = get_with_fallback(data, "other", dict)
         self._http: HTTPClientT = http
 
     @property
-    def background(self) -> Optional[Asset[HTTPClientT]]:
+    def background(self) -> Asset[HTTPClientT] | None:
         """
         Optional[:class:`~fortnite_api.Asset`]: The background image of the cosmetic, if available.
         """
@@ -299,7 +299,7 @@ class CosmeticImages(Images[HTTPClientT]):
         return Asset(http=self._http, url=url)
 
     @property
-    def coverart(self) -> Optional[Asset[HTTPClientT]]:
+    def coverart(self) -> Asset[HTTPClientT] | None:
         """
         Optional[:class:`~fortnite_api.Asset`]: The cover art image of the cosmetic, if available.
         """
@@ -310,7 +310,7 @@ class CosmeticImages(Images[HTTPClientT]):
         return Asset(http=self._http, url=url)
 
     @property
-    def decal(self) -> Optional[Asset[HTTPClientT]]:
+    def decal(self) -> Asset[HTTPClientT] | None:
         """
         Optional[:class:`~fortnite_api.Asset`]: The decal image of the cosmetic, if available.
         """

--- a/fortnite_api/cosmetics/instrument.py
+++ b/fortnite_api/cosmetics/instrument.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Optional
+from typing import Any
 
 from ..http import HTTPClientT
 from ..utils import get_with_fallback, parse_time, simple_repr
@@ -99,29 +99,27 @@ class CosmeticInstrument(Cosmetic[dict[str, Any], HTTPClientT]):
         self.description: str = data['description']
 
         _type = data.get('type')
-        self.type: Optional[CosmeticTypeInfo[HTTPClientT]] = _type and CosmeticTypeInfo(data=_type, http=http)
+        self.type: CosmeticTypeInfo[HTTPClientT] | None = _type and CosmeticTypeInfo(data=_type, http=http)
 
         _rarity = data.get('rarity')
-        self.rarity: Optional[CosmeticRarityInfo[HTTPClientT]] = _rarity and CosmeticRarityInfo(data=_rarity, http=http)
+        self.rarity: CosmeticRarityInfo[HTTPClientT] | None = _rarity and CosmeticRarityInfo(data=_rarity, http=http)
 
         _images = data.get('images')
-        self.images: Optional[CosmeticImages[HTTPClientT]] = _images and CosmeticImages(data=_images, http=http)
+        self.images: CosmeticImages[HTTPClientT] | None = _images and CosmeticImages(data=_images, http=http)
 
         _series = data.get('series')
-        self.series: Optional[CosmeticSeriesInfo[HTTPClientT]] = _series and CosmeticSeriesInfo(
-            data=_series, http=self._http
-        )
+        self.series: CosmeticSeriesInfo[HTTPClientT] | None = _series and CosmeticSeriesInfo(data=_series, http=self._http)
 
         self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplayTags', list)
-        self.path: Optional[str] = data.get('path')
-        self.showcase_video_id: Optional[str] = data.get('showcaseVideo')
+        self.path: str | None = data.get('path')
+        self.showcase_video_id: str | None = data.get('showcaseVideo')
 
         self.shop_history: list[datetime.datetime] = [
             parse_time(time) for time in get_with_fallback(data, 'shopHistory', list)
         ]
 
     @property
-    def showcase_video_url(self) -> Optional[str]:
+    def showcase_video_url(self) -> str | None:
         """Optional[:class:`str`]: The URL of the YouTube showcase video of the cosmetic, if any."""
         _id = self.showcase_video_id
         if not _id:

--- a/fortnite_api/cosmetics/lego_kit.py
+++ b/fortnite_api/cosmetics/lego_kit.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from ..http import HTTPClientT
 from ..utils import get_with_fallback, parse_time, simple_repr
@@ -78,15 +78,15 @@ class CosmeticLegoKit(Cosmetic[dict[str, Any], HTTPClientT]):
         self.name: str = data['name']
 
         _type = data.get('type')
-        self.type: Optional[CosmeticTypeInfo[HTTPClientT]] = _type and CosmeticTypeInfo(data=_type, http=http)
+        self.type: CosmeticTypeInfo[HTTPClientT] | None = _type and CosmeticTypeInfo(data=_type, http=http)
 
         _series = data.get('series')
-        self.series: Optional[CosmeticSeriesInfo[HTTPClientT]] = _series and CosmeticSeriesInfo(data=_series, http=http)
+        self.series: CosmeticSeriesInfo[HTTPClientT] | None = _series and CosmeticSeriesInfo(data=_series, http=http)
 
         self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplayTags', list)
 
         _images = data.get('images')
-        self.images: Optional[CosmeticImages[HTTPClientT]] = _images and CosmeticImages(data=_images, http=http)
+        self.images: CosmeticImages[HTTPClientT] | None = _images and CosmeticImages(data=_images, http=http)
 
-        self.path: Optional[str] = data.get('path')
+        self.path: str | None = data.get('path')
         self.shop_history = [parse_time(time) for time in get_with_fallback(data, 'shopHistory', list)]

--- a/fortnite_api/cosmetics/track.py
+++ b/fortnite_api/cosmetics/track.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Optional
+from typing import Any
 
 from ..abc import ReconstructAble
 from ..asset import Asset
@@ -147,7 +147,7 @@ class CosmeticTrack(Cosmetic[dict[str, Any], HTTPClientT]):
         self.dev_name: str = data['devName']
         self.title: str = data['title']
         self.artist: str = data['artist']
-        self.album: Optional[str] = data.get('album')
+        self.album: str | None = data.get('album')
         self.release_year: int = data['releaseYear']
         self.bpm: int = data['bpm']
         self.duration: int = data['duration']

--- a/fortnite_api/cosmetics/variants/bean.py
+++ b/fortnite_api/cosmetics/variants/bean.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 from collections.abc import Coroutine
-from typing import TYPE_CHECKING, Any, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, overload
 
 from ...enums import CustomGender, GameLanguage, try_enum
 from ...http import HTTPClientT
@@ -74,26 +74,24 @@ class VariantBean(Cosmetic[dict[str, Any], HTTPClientT]):
     def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         super().__init__(data=data, http=http)
 
-        self.cosmetic_id: Optional[str] = data.get('cosmetic_id')
+        self.cosmetic_id: str | None = data.get('cosmetic_id')
         self.name: str = data['name']
         self.gender: CustomGender = try_enum(CustomGender, data['gender'] if 'gender' in data else 'Unknown')
         self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplay_tags', list)
 
         _images = data.get('images')
-        self.images: Optional[CosmeticImages[HTTPClientT]] = _images and CosmeticImages(data=_images, http=http)
-        self.path: Optional[str] = data.get('path')
+        self.images: CosmeticImages[HTTPClientT] | None = _images and CosmeticImages(data=_images, http=http)
+        self.path: str | None = data.get('path')
 
     @overload
     def fetch_cosmetic_br(
-        self: VariantBean[HTTPClient], *, language: Optional[GameLanguage] = None
+        self: VariantBean[HTTPClient], *, language: GameLanguage | None = None
     ) -> Coroutine[Any, Any, CosmeticBr]: ...
 
     @overload
-    def fetch_cosmetic_br(self: VariantBean[SyncHTTPClient], *, language: Optional[GameLanguage] = None) -> CosmeticBr: ...
+    def fetch_cosmetic_br(self: VariantBean[SyncHTTPClient], *, language: GameLanguage | None = None) -> CosmeticBr: ...
 
-    def fetch_cosmetic_br(
-        self, *, language: Optional[GameLanguage] = None
-    ) -> Union[Coroutine[Any, Any, CosmeticBr], CosmeticBr]:
+    def fetch_cosmetic_br(self, *, language: GameLanguage | None = None) -> Coroutine[Any, Any, CosmeticBr] | CosmeticBr:
         """|coro|
 
         Fetches the Battle Royale cosmetic that this bean variant is based on.

--- a/fortnite_api/cosmetics/variants/lego.py
+++ b/fortnite_api/cosmetics/variants/lego.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 from collections.abc import Coroutine
-from typing import TYPE_CHECKING, Any, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, overload
 
 from ...enums import GameLanguage
 from ...http import HTTPClientT
@@ -78,20 +78,18 @@ class VariantLego(Cosmetic[dict[str, Any], HTTPClientT]):
         self.sound_library_tags: list[str] = get_with_fallback(data, 'soundLibraryTags', list)
 
         _images = data.get('images')
-        self.images: Optional[CosmeticImages[HTTPClientT]] = _images and CosmeticImages(data=_images, http=http)
-        self.path: Optional[str] = data.get('path')
+        self.images: CosmeticImages[HTTPClientT] | None = _images and CosmeticImages(data=_images, http=http)
+        self.path: str | None = data.get('path')
 
     @overload
     def fetch_cosmetic_br(
-        self: VariantLego[HTTPClient], *, language: Optional[GameLanguage] = None
+        self: VariantLego[HTTPClient], *, language: GameLanguage | None = None
     ) -> Coroutine[Any, Any, CosmeticBr]: ...
 
     @overload
-    def fetch_cosmetic_br(self: VariantLego[SyncHTTPClient], *, language: Optional[GameLanguage] = None) -> CosmeticBr: ...
+    def fetch_cosmetic_br(self: VariantLego[SyncHTTPClient], *, language: GameLanguage | None = None) -> CosmeticBr: ...
 
-    def fetch_cosmetic_br(
-        self, *, language: Optional[GameLanguage] = None
-    ) -> Union[Coroutine[Any, Any, CosmeticBr], CosmeticBr]:
+    def fetch_cosmetic_br(self, *, language: GameLanguage | None = None) -> Coroutine[Any, Any, CosmeticBr] | CosmeticBr:
         """|coro|
 
         Fetches the Battle Royale cosmetic that this lego cosmetic variant is based on.

--- a/fortnite_api/errors.py
+++ b/fortnite_api/errors.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import aiohttp
@@ -75,11 +75,9 @@ class HTTPException(FortniteAPIException):
         The raw data that was returned from the API.
     """
 
-    def __init__(
-        self, message: Optional[str], response: Union[aiohttp.ClientResponse, requests.Response], data: Any, /
-    ) -> None:
-        self.message: Optional[str] = message
-        self.response: Union[aiohttp.ClientResponse, requests.Response] = response
+    def __init__(self, message: str | None, response: aiohttp.ClientResponse | requests.Response, data: Any, /) -> None:
+        self.message: str | None = message
+        self.response: aiohttp.ClientResponse | requests.Response = response
         self.data: Any = data
         super().__init__(message)
 

--- a/fortnite_api/http.py
+++ b/fortnite_api/http.py
@@ -30,12 +30,12 @@ import logging
 import sys
 import time
 from collections.abc import Coroutine
-from typing import Any, ClassVar, Literal, Optional, Union
+from typing import Any, ClassVar, Literal, TypeAlias, Union
 from urllib.parse import quote as _uriquote
 
 import aiohttp
 import requests
-from typing_extensions import TypeAlias, TypeVar
+from typing_extensions import TypeVar
 
 from . import __version__
 from .errors import *
@@ -74,7 +74,7 @@ class Route:
     def __init__(self, method: str, path: str, **params: Any) -> None:
         self.method: str = method
         self.path: str = path
-        self.params: Optional[dict[str, Any]] = params
+        self.params: dict[str, Any] | None = params
 
         url = self.BASE_URL + path
         if params:
@@ -90,8 +90,8 @@ class Route:
 
 class HTTPMixin(abc.ABC):
 
-    def __init__(self, *, token: Optional[str] = None) -> None:
-        self.token: Optional[str] = token
+    def __init__(self, *, token: str | None = None) -> None:
+        self.token: str | None = token
 
         self.user_agent = 'FortniteApi (https://github.com/Fortnite-API/py-wrapper {0}) Python/{1[0]}.{1[1]}'.format(
             __version__, sys.version_info
@@ -104,9 +104,9 @@ class HTTPMixin(abc.ABC):
     @abc.abstractmethod
     def request(self, route: Route, **kwargs: Any) -> Any: ...
 
-    def get_cosmetics_br(self, language: Optional[str] = None, response_flags: Optional[int] = None):
+    def get_cosmetics_br(self, language: str | None = None, response_flags: int | None = None):
         r: Route = Route('GET', '/v2/cosmetics/br')
-        params: dict[str, Union[str, int]] = {}
+        params: dict[str, str | int] = {}
 
         if language:
             params['language'] = language
@@ -116,9 +116,9 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_cosmetics_cars(self, language: Optional[str] = None, response_flags: Optional[int] = None):
+    def get_cosmetics_cars(self, language: str | None = None, response_flags: int | None = None):
         r: Route = Route('GET', '/v2/cosmetics/cars')
-        params: dict[str, Union[str, int]] = {}
+        params: dict[str, str | int] = {}
 
         if language:
             params['language'] = language
@@ -128,9 +128,9 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_cosmetics_instruments(self, language: Optional[str] = None, response_flags: Optional[int] = None):
+    def get_cosmetics_instruments(self, language: str | None = None, response_flags: int | None = None):
         r: Route = Route('GET', '/v2/cosmetics/instruments')
-        params: dict[str, Union[str, int]] = {}
+        params: dict[str, str | int] = {}
 
         if language:
             params['language'] = language
@@ -140,9 +140,9 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_cosmetics_lego_kits(self, language: Optional[str] = None, response_flags: Optional[int] = None):
+    def get_cosmetics_lego_kits(self, language: str | None = None, response_flags: int | None = None):
         r: Route = Route('GET', '/v2/cosmetics/lego/kits')
-        params: dict[str, Union[str, int]] = {}
+        params: dict[str, str | int] = {}
 
         if language:
             params['language'] = language
@@ -152,9 +152,9 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_cosmetics_tracks(self, language: Optional[str] = None, response_flags: Optional[int] = None):
+    def get_cosmetics_tracks(self, language: str | None = None, response_flags: int | None = None):
         r: Route = Route('GET', '/v2/cosmetics/tracks')
-        params: dict[str, Union[str, int]] = {}
+        params: dict[str, str | int] = {}
 
         if language:
             params['language'] = language
@@ -164,9 +164,9 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_cosmetics_lego(self, language: Optional[str] = None, response_flags: Optional[int] = None):
+    def get_cosmetics_lego(self, language: str | None = None, response_flags: int | None = None):
         r: Route = Route('GET', '/v2/cosmetics/lego')
-        params: dict[str, Union[str, int]] = {}
+        params: dict[str, str | int] = {}
 
         if language:
             params['language'] = language
@@ -176,9 +176,9 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_cosmetics_beans(self, language: Optional[str] = None, response_flags: Optional[int] = None):
+    def get_cosmetics_beans(self, language: str | None = None, response_flags: int | None = None):
         r: Route = Route('GET', '/v2/cosmetics/beans')
-        params: dict[str, Union[str, int]] = {}
+        params: dict[str, str | int] = {}
 
         if language:
             params['language'] = language
@@ -188,9 +188,9 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_cosmetics_new(self, language: Optional[str] = None, response_flags: Optional[int] = None):
+    def get_cosmetics_new(self, language: str | None = None, response_flags: int | None = None):
         r: Route = Route('GET', '/v2/cosmetics/new')
-        params: dict[str, Union[str, int]] = {}
+        params: dict[str, str | int] = {}
 
         if language:
             params['language'] = language
@@ -200,9 +200,9 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_cosmetic_br(self, id: str, language: Optional[str] = None, response_flags: Optional[int] = None):
+    def get_cosmetic_br(self, id: str, language: str | None = None, response_flags: int | None = None):
         r: Route = Route('GET', '/v2/cosmetics/br/{id}', id=id)
-        params: dict[str, Union[str, int]] = {}
+        params: dict[str, str | int] = {}
 
         if language:
             params['language'] = language
@@ -212,9 +212,9 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_cosmetics_all(self, language: Optional[str] = None, response_flags: Optional[int] = None):
+    def get_cosmetics_all(self, language: str | None = None, response_flags: int | None = None):
         r: Route = Route('GET', '/v2/cosmetics')
-        params: dict[str, Union[str, int]] = {}
+        params: dict[str, str | int] = {}
 
         if language:
             params['language'] = language
@@ -229,7 +229,7 @@ class HTTPMixin(abc.ABC):
         params: dict[str, str] = {'keyFormat': key_format}
         return self.request(r, params=params)
 
-    def get_banners(self, language: Optional[str] = None):
+    def get_banners(self, language: str | None = None):
         r: Route = Route('GET', '/v1/banners')
         params: dict[str, str] = {}
 
@@ -256,7 +256,7 @@ class HTTPMixin(abc.ABC):
         params: dict[str, str] = {'name': name}
         return self.request(r, params=params)
 
-    def get_map(self, language: Optional[str] = None):
+    def get_map(self, language: str | None = None):
         r: Route = Route('GET', '/v1/map')
         params: dict[str, str] = {}
 
@@ -265,7 +265,7 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_news(self, language: Optional[str] = None):
+    def get_news(self, language: str | None = None):
         r: Route = Route('GET', '/v2/news')
         params: dict[str, str] = {}
 
@@ -274,7 +274,7 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_news_br(self, language: Optional[str] = None):
+    def get_news_br(self, language: str | None = None):
         r: Route = Route('GET', '/v2/news/br')
         params: dict[str, str] = {}
 
@@ -283,7 +283,7 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_news_stw(self, language: Optional[str] = None):
+    def get_news_stw(self, language: str | None = None):
         r: Route = Route('GET', '/v2/news/stw')
         params: dict[str, str] = {}
 
@@ -292,7 +292,7 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_playlists(self, language: Optional[str] = None):
+    def get_playlists(self, language: str | None = None):
         r: Route = Route('GET', '/v1/playlists')
         params: dict[str, str] = {}
 
@@ -301,7 +301,7 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_playlist(self, id: str, language: Optional[str] = None):
+    def get_playlist(self, id: str, language: str | None = None):
         r: Route = Route('GET', '/v1/playlists/{id}', id=id)
         params: dict[str, str] = {}
 
@@ -310,9 +310,9 @@ class HTTPMixin(abc.ABC):
 
         return self.request(r, params=params)
 
-    def get_shop(self, language: Optional[str] = None, response_flags: Optional[int] = None):
+    def get_shop(self, language: str | None = None, response_flags: int | None = None):
         r: Route = Route('GET', '/v2/shop')
-        params: dict[str, Union[str, int]] = {}
+        params: dict[str, str | int] = {}
 
         if language:
             params['language'] = language
@@ -355,15 +355,15 @@ class HTTPMixin(abc.ABC):
 
 
 class HTTPClient(HTTPMixin):
-    def __init__(self, *args: Any, session: Optional[aiohttp.ClientSession] = None, **kwargs: Any) -> None:
-        self.session: Optional[aiohttp.ClientSession] = session
+    def __init__(self, *args: Any, session: aiohttp.ClientSession | None = None, **kwargs: Any) -> None:
+        self.session: aiohttp.ClientSession | None = session
         super().__init__(*args, **kwargs)
 
     async def close(self) -> None:
         if self.session is not None:
             await self.session.close()
 
-    async def _parse_async_response(self, response: aiohttp.ClientResponse) -> Union[dict[str, Any], str, bytes]:
+    async def _parse_async_response(self, response: aiohttp.ClientResponse) -> dict[str, Any] | str | bytes:
         try:
             text = await response.text()
         except UnicodeDecodeError:
@@ -381,7 +381,7 @@ class HTTPClient(HTTPMixin):
                 'aiohttp.ClientSession is not set. Must either pass session to Client constructor or use the async context manager.'
             )
 
-        response: Optional[aiohttp.ClientResponse] = None
+        response: aiohttp.ClientResponse | None = None
         data = None
         error = None
 
@@ -443,15 +443,15 @@ class HTTPClient(HTTPMixin):
 
 
 class SyncHTTPClient(HTTPMixin):
-    def __init__(self, *args: Any, session: Optional[requests.Session] = None, **kwargs: Any) -> None:
-        self.session: Optional[requests.Session] = session
+    def __init__(self, *args: Any, session: requests.Session | None = None, **kwargs: Any) -> None:
+        self.session: requests.Session | None = session
         super().__init__(*args, **kwargs)
 
     def close(self) -> None:
         if self.session is not None:
             self.session.close()
 
-    def _parse_sync_response(self, response: requests.Response) -> Union[dict[str, Any], str, bytes]:
+    def _parse_sync_response(self, response: requests.Response) -> dict[str, Any] | str | bytes:
         content_type = response.headers.get('Content-Type')
         if content_type and content_type.startswith('image/'):
             return response.content
@@ -472,7 +472,7 @@ class SyncHTTPClient(HTTPMixin):
                 'requests.Session is not set. Must either pass session to Client constructor or use the context manager.'
             )
 
-        response: Optional[requests.Response] = None
+        response: requests.Response | None = None
         data = None
         error = None
         for tries in range(5):

--- a/fortnite_api/http.py
+++ b/fortnite_api/http.py
@@ -30,7 +30,7 @@ import logging
 import sys
 import time
 from collections.abc import Coroutine
-from typing import Any, ClassVar, Literal, TypeAlias, Union
+from typing import Any, ClassVar, Literal, TypeAlias
 from urllib.parse import quote as _uriquote
 
 import aiohttp
@@ -44,7 +44,7 @@ from .utils import now, parse_time, to_json
 T = TypeVar('T', bound='Any')
 AsyncResponse: TypeAlias = Coroutine[Any, Any, T]
 
-HTTPClientT = TypeVar('HTTPClientT', bound='Union[HTTPClient, SyncHTTPClient]', default='HTTPClient')
+HTTPClientT = TypeVar('HTTPClientT', bound='HTTPClient | SyncHTTPClient', default='HTTPClient')
 
 _log = logging.getLogger(__name__)
 

--- a/fortnite_api/images.py
+++ b/fortnite_api/images.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from .abc import ReconstructAble
 from .asset import Asset
@@ -64,7 +64,7 @@ class Images(ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         small_icon = data.get('smallIcon')
-        self.small_icon: Optional[Asset[HTTPClientT]] = small_icon and Asset(http=http, url=small_icon)
+        self.small_icon: Asset[HTTPClientT] | None = small_icon and Asset(http=http, url=small_icon)
 
         icon = data.get('icon')
-        self.icon: Optional[Asset[HTTPClientT]] = icon and Asset(http=http, url=icon)
+        self.icon: Asset[HTTPClientT] | None = icon and Asset(http=http, url=icon)

--- a/fortnite_api/map.py
+++ b/fortnite_api/map.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import Any, Optional
+from typing import Any
 
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
@@ -156,7 +156,7 @@ class POI(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         self.id: str = data["id"]
-        self.name: Optional[str] = data.get("name")
+        self.name: str | None = data.get("name")
         self.location: POILocation[HTTPClientT] = POILocation(data=data["location"], http=http)
 
 

--- a/fortnite_api/new.py
+++ b/fortnite_api/new.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Generic, Optional
+from typing import Any, Generic
 
 from .abc import ReconstructAble
 from .cosmetics import (
@@ -90,13 +90,13 @@ class NewCosmetic(Generic[CosmeticT]):
         self,
         *,
         type: CosmeticCategory,
-        hash: Optional[str] = None,
-        last_addition: Optional[datetime.datetime] = None,
+        hash: str | None = None,
+        last_addition: datetime.datetime | None = None,
         items: list[CosmeticT],
     ) -> None:
         self.type: CosmeticCategory = type
-        self.hash: Optional[str] = hash
-        self.last_addition: Optional[datetime.datetime] = last_addition
+        self.hash: str | None = hash
+        self.last_addition: datetime.datetime | None = last_addition
         self.items: list[CosmeticT] = items
 
 
@@ -211,7 +211,7 @@ class NewCosmetics(ReconstructAble[dict[str, Any], HTTPClientT]):
         cosmetic_items: list[dict[str, Any]] = get_with_fallback(self._items, internal_key, list)
 
         last_addition_str = self._last_additions[internal_key]
-        last_addition: Optional[datetime.datetime] = last_addition_str and parse_time(last_addition_str)
+        last_addition: datetime.datetime | None = last_addition_str and parse_time(last_addition_str)
 
         return NewCosmetic(
             type=cosmetic_type,

--- a/fortnite_api/new_display_asset.py
+++ b/fortnite_api/new_display_asset.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
@@ -102,10 +102,10 @@ class MaterialInstanceImages(dict[str, Asset[HTTPClientT]]):
 
     def __init__(self, *, data: dict[str, Any], http: HTTPClientT) -> None:
         _offer_image = data.get("OfferImage")
-        self.offer_image: Optional[Asset[HTTPClientT]] = _offer_image and Asset(url=_offer_image, http=http)
+        self.offer_image: Asset[HTTPClientT] | None = _offer_image and Asset(url=_offer_image, http=http)
 
         _background = data.get("Background", None)
-        self.background: Optional[Asset[HTTPClientT]] = _background and Asset(url=_background, http=http)
+        self.background: Asset[HTTPClientT] | None = _background and Asset(url=_background, http=http)
 
         # Transform all remaining keys into assets, and pass this along to the dict constructor
         super().__init__({key: Asset(url=value, http=http) for key, value in data.items()})
@@ -139,9 +139,9 @@ class MaterialInstanceColors(dict[str, str]):
     )
 
     def __init__(self, *, data: dict[str, Any]) -> None:
-        self.background_color_a: Optional[str] = data.get("Background_Color_A")
-        self.background_color_b: Optional[str] = data.get("Background_Color_B")
-        self.fall_off_color: Optional[str] = data.get("FallOff_Color")
+        self.background_color_a: str | None = data.get("Background_Color_A")
+        self.background_color_b: str | None = data.get("Background_Color_B")
+        self.fall_off_color: str | None = data.get("FallOff_Color")
         super().__init__(data)
 
 
@@ -208,7 +208,7 @@ class MaterialInstance(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
         self.images: MaterialInstanceImages[HTTPClientT] = MaterialInstanceImages(data=data["images"], http=http)
 
         _colors = data.get("colors")
-        self.colors: Optional[MaterialInstanceColors] = _colors and MaterialInstanceColors(data=_colors)
+        self.colors: MaterialInstanceColors | None = _colors and MaterialInstanceColors(data=_colors)
         self.scalings: dict[str, Any] = get_with_fallback(data, "scalings", dict)
 
         self.flags: dict[str, Any] = get_with_fallback(data, "flags", dict)  # This is always None at this time.
@@ -244,7 +244,7 @@ class NewDisplayAsset(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         self.id: str = data["id"]
-        self.cosmetic_id: Optional[str] = data.get("cosmeticId")
+        self.cosmetic_id: str | None = data.get("cosmeticId")
         self.material_instances: list[MaterialInstance[HTTPClientT]] = [
             MaterialInstance(data=instance, http=http) for instance in get_with_fallback(data, "materialInstances", list)
         ]

--- a/fortnite_api/news.py
+++ b/fortnite_api/news.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
@@ -70,10 +70,10 @@ class News(ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         _br = data.get("br")
-        self.br: Optional[GameModeNews[HTTPClientT]] = _br and GameModeNews(data=_br, http=http)
+        self.br: GameModeNews[HTTPClientT] | None = _br and GameModeNews(data=_br, http=http)
 
         _stw = data.get("stw")
-        self.stw: Optional[GameModeNews[HTTPClientT]] = _stw and GameModeNews(data=_stw, http=http)
+        self.stw: GameModeNews[HTTPClientT] | None = _stw and GameModeNews(data=_stw, http=http)
 
 
 @simple_repr
@@ -115,7 +115,7 @@ class GameModeNews(ReconstructAble[dict[str, Any], HTTPClientT]):
         self.date: datetime.datetime = parse_time(data["date"])
 
         _image = data.get("image")
-        self.image: Optional[Asset[HTTPClientT]] = _image and Asset(http=http, url=_image)
+        self.image: Asset[HTTPClientT] | None = _image and Asset(http=http, url=_image)
 
         _motds = get_with_fallback(data, "motds", list)
         self.motds: list[NewsMotd[HTTPClientT]] = [NewsMotd(data=motd, http=http) for motd in _motds]
@@ -221,4 +221,4 @@ class NewsMessage(ReconstructAble[dict[str, Any], HTTPClientT]):
         self.title: str = data["title"]
         self.body: str = data["body"]
         self.image: Asset[HTTPClientT] = Asset(http=http, url=data["image"])
-        self.adspace: Optional[str] = data.get("adspace")
+        self.adspace: str | None = data.get("adspace")

--- a/fortnite_api/playlist.py
+++ b/fortnite_api/playlist.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from .abc import Hashable, ReconstructAble
 from .asset import Asset
@@ -59,10 +59,10 @@ class PlaylistImages(ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         _showcase = data.get('showcase')
-        self.showcase: Optional[Asset[HTTPClientT]] = _showcase and Asset(url=_showcase, http=http)
+        self.showcase: Asset[HTTPClientT] | None = _showcase and Asset(url=_showcase, http=http)
 
         _mission_icon = data.get('missionIcon')
-        self.mission_icon: Optional[Asset[HTTPClientT]] = _mission_icon and Asset(url=_mission_icon, http=http)
+        self.mission_icon: Asset[HTTPClientT] | None = _mission_icon and Asset(url=_mission_icon, http=http)
 
 
 class Playlist(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
@@ -144,11 +144,11 @@ class Playlist(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
         self.id: str = data['id']
         self.name: str = data['name']
-        self.sub_name: Optional[str] = data.get('subName')
-        self.description: Optional[str] = data.get('description')
+        self.sub_name: str | None = data.get('subName')
+        self.description: str | None = data.get('description')
 
-        self.game_type: Optional[str] = data.get('gameType')  # TODO: Make this into an enum
-        self.rating_type: Optional[str] = data.get('ratingType')
+        self.game_type: str | None = data.get('gameType')  # TODO: Make this into an enum
+        self.rating_type: str | None = data.get('ratingType')
 
         self.min_players: int = data['minPlayers']
         self.max_players: int = data['maxPlayers']
@@ -164,7 +164,7 @@ class Playlist(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
         self.accumulate_to_profile_stats: bool = data['accumulateToProfileStats']
 
         _images = data.get('images')
-        self.images: Optional[PlaylistImages[HTTPClientT]] = _images and PlaylistImages(data=_images, http=http)
+        self.images: PlaylistImages[HTTPClientT] | None = _images and PlaylistImages(data=_images, http=http)
 
         self.gameplay_tags: list[str] = get_with_fallback(data, 'gameplayTags', list)
         self.path: str = data['path']

--- a/fortnite_api/proxies.py
+++ b/fortnite_api/proxies.py
@@ -24,8 +24,8 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
-from typing import TYPE_CHECKING, Callable, Generic, SupportsIndex, Union, cast, overload
+from collections.abc import Callable, Iterable, Iterator
+from typing import TYPE_CHECKING, Generic, SupportsIndex, cast, overload
 
 from typing_extensions import Self, TypeVar
 
@@ -92,7 +92,7 @@ class TransformerListProxy(Generic[T, K_co, V_co], list[T]):
     @overload
     def __getitem__(self, index: slice) -> list[T]: ...
 
-    def __getitem__(self, index: Union[SupportsIndex, slice]) -> Union[list[T], T]:
+    def __getitem__(self, index: SupportsIndex | slice) -> list[T] | T:
         if isinstance(index, slice):
             # This is a slice, so we need to handle each item in the slice and set it to the transformed data.
             # For each index in the slice, transform the data at that index then update the item list

--- a/fortnite_api/shop.py
+++ b/fortnite_api/shop.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import datetime
 import re
 from collections.abc import Generator
-from typing import Any, Optional
+from typing import Any
 
 from typing_extensions import Self
 
@@ -263,16 +263,16 @@ class ShopEntryLayout(Hashable, ReconstructAble[dict[str, Any], HTTPClientT]):
 
         self.id: str = data["id"]
         self.name: str = data["name"]
-        self.category: Optional[str] = data.get("category")
+        self.category: str | None = data.get("category")
         self.index: int = data["index"]
         self.rank: int = data["rank"]
         self.show_ineligible_offers: str = data["showIneligibleOffers"]
 
         _background = data.get("background")
-        self.background: Optional[Asset[HTTPClientT]] = _background and Asset(url=_background, http=http)
+        self.background: Asset[HTTPClientT] | None = _background and Asset(url=_background, http=http)
 
         self.use_wide_preview: bool = data.get('useWidePreview', False)
-        self.display_type: Optional[str] = data.get('displayType')
+        self.display_type: str | None = data.get('displayType')
         # Billboards include textureMetadata, stringMetadata and textMetadata
 
 
@@ -300,9 +300,9 @@ class ShopEntryColors(ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         self.color1: str = data['color1']
-        self.color2: Optional[str] = data.get('color2')
+        self.color2: str | None = data.get('color2')
         self.color3: str = data['color3']
-        self.text_background_color: Optional[str] = data.get('textBackgroundColor')
+        self.text_background_color: str | None = data.get('textBackgroundColor')
 
 
 class ShopEntry(ReconstructAble[dict[str, Any], HTTPClientT]):
@@ -429,15 +429,13 @@ class ShopEntry(ReconstructAble[dict[str, Any], HTTPClientT]):
         self.out_date: datetime.datetime = parse_time(data["outDate"])
 
         _offer_tag = data.get("offerTag")
-        self.offer_tag: Optional[ShopEntryOfferTag[HTTPClientT]] = _offer_tag and ShopEntryOfferTag(
-            data=_offer_tag, http=http
-        )
+        self.offer_tag: ShopEntryOfferTag[HTTPClientT] | None = _offer_tag and ShopEntryOfferTag(data=_offer_tag, http=http)
 
         _bundle = data.get("bundle")
-        self.bundle: Optional[ShopEntryBundle[HTTPClientT]] = _bundle and ShopEntryBundle(data=_bundle, http=http)
+        self.bundle: ShopEntryBundle[HTTPClientT] | None = _bundle and ShopEntryBundle(data=_bundle, http=http)
 
         _banner = data.get("banner")
-        self.banner: Optional[ShopEntryBanner[HTTPClientT]] = _banner and ShopEntryBanner(data=_banner, http=http)
+        self.banner: ShopEntryBanner[HTTPClientT] | None = _banner and ShopEntryBanner(data=_banner, http=http)
 
         self.giftable: bool = data["giftable"]
         self.refundable: bool = data["refundable"]
@@ -445,23 +443,23 @@ class ShopEntry(ReconstructAble[dict[str, Any], HTTPClientT]):
         self.layout_id: str = data["layoutId"]
 
         _layout = data.get("layout")
-        self.layout: Optional[ShopEntryLayout[HTTPClientT]] = _layout and ShopEntryLayout(data=_layout, http=http)
+        self.layout: ShopEntryLayout[HTTPClientT] | None = _layout and ShopEntryLayout(data=_layout, http=http)
 
         self.dev_name: str = data["devName"]
         self.offer_id: str = data["offerId"]
-        self.display_asset_path: Optional[str] = data.get("displayAssetPath")
+        self.display_asset_path: str | None = data.get("displayAssetPath")
 
         self.tile_size: TileSize = TileSize.from_value(data["tileSize"])
 
-        self.new_display_asset_path: Optional[str] = data.get("newDisplayAssetPath")
+        self.new_display_asset_path: str | None = data.get("newDisplayAssetPath")
 
         _new_display_asset = data.get("newDisplayAsset")
-        self.new_display_asset: Optional[NewDisplayAsset[HTTPClientT]] = _new_display_asset and NewDisplayAsset(
+        self.new_display_asset: NewDisplayAsset[HTTPClientT] | None = _new_display_asset and NewDisplayAsset(
             data=data["newDisplayAsset"], http=http
         )
 
         _colors = data.get("colors")
-        self.colors: Optional[ShopEntryColors[HTTPClientT]] = _colors and ShopEntryColors(data=_colors, http=http)
+        self.colors: ShopEntryColors[HTTPClientT] | None = _colors and ShopEntryColors(data=_colors, http=http)
 
         self.br: list[CosmeticBr[HTTPClientT]] = TransformerListProxy(
             get_with_fallback(data, "brItems", list),

--- a/fortnite_api/stats.py
+++ b/fortnite_api/stats.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from .abc import ReconstructAble
 from .account import Account
@@ -65,7 +65,7 @@ class BrBattlePass(ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         self.level: int = data["level"]
-        self.progress: Optional[int] = data["progress"]
+        self.progress: int | None = data["progress"]
 
 
 class BrGameModeStats(ReconstructAble[dict[str, Any], HTTPClientT]):
@@ -163,12 +163,12 @@ class BrGameModeStats(ReconstructAble[dict[str, Any], HTTPClientT]):
         self.score_per_match: float = data["scorePerMatch"]
         self.wins: int = data["wins"]
 
-        self.top3: Optional[int] = data.get("top3")
-        self.top5: Optional[int] = data.get("top5")
-        self.top6: Optional[int] = data.get("top6")
-        self.top10: Optional[int] = data.get("top10")
-        self.top12: Optional[int] = data.get("top12")
-        self.top25: Optional[int] = data.get("top25")
+        self.top3: int | None = data.get("top3")
+        self.top5: int | None = data.get("top5")
+        self.top6: int | None = data.get("top6")
+        self.top10: int | None = data.get("top10")
+        self.top12: int | None = data.get("top12")
+        self.top25: int | None = data.get("top25")
 
         self.kills: int = data["kills"]
         self.kills_per_min: float = data["killsPerMin"]
@@ -208,16 +208,16 @@ class BrInputStats(ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         _overall = data.get("overall")
-        self.overall: Optional[BrGameModeStats[HTTPClientT]] = _overall and BrGameModeStats(data=_overall, http=http)
+        self.overall: BrGameModeStats[HTTPClientT] | None = _overall and BrGameModeStats(data=_overall, http=http)
 
         _solo = data.get("solo")
-        self.solo: Optional[BrGameModeStats[HTTPClientT]] = _solo and BrGameModeStats(data=_solo, http=http)
+        self.solo: BrGameModeStats[HTTPClientT] | None = _solo and BrGameModeStats(data=_solo, http=http)
 
         _duo = data.get("duo")
-        self.duo: Optional[BrGameModeStats[HTTPClientT]] = _duo and BrGameModeStats(data=_duo, http=http)
+        self.duo: BrGameModeStats[HTTPClientT] | None = _duo and BrGameModeStats(data=_duo, http=http)
 
         _squad = data.get("squad")
-        self.squad: Optional[BrGameModeStats[HTTPClientT]] = _squad and BrGameModeStats(data=_squad, http=http)
+        self.squad: BrGameModeStats[HTTPClientT] | None = _squad and BrGameModeStats(data=_squad, http=http)
 
 
 class BrInputs(ReconstructAble[dict[str, Any], HTTPClientT]):
@@ -250,18 +250,18 @@ class BrInputs(ReconstructAble[dict[str, Any], HTTPClientT]):
         super().__init__(data=data, http=http)
 
         _all = data.get("all")
-        self.all: Optional[BrInputStats[HTTPClientT]] = _all and BrInputStats(data=_all, http=http)
+        self.all: BrInputStats[HTTPClientT] | None = _all and BrInputStats(data=_all, http=http)
 
         _keyboard_mouse = data.get("keyboardMouse")
-        self.keyboard_mouse: Optional[BrInputStats[HTTPClientT]] = _keyboard_mouse and BrInputStats(
+        self.keyboard_mouse: BrInputStats[HTTPClientT] | None = _keyboard_mouse and BrInputStats(
             data=_keyboard_mouse, http=http
         )
 
         _gamepad = data.get("gamepad")
-        self.gamepad: Optional[BrInputStats[HTTPClientT]] = _gamepad and BrInputStats(data=_gamepad, http=http)
+        self.gamepad: BrInputStats[HTTPClientT] | None = _gamepad and BrInputStats(data=_gamepad, http=http)
 
         _touch = data.get("touch")
-        self.touch: Optional[BrInputStats[HTTPClientT]] = _touch and BrInputStats(data=_touch, http=http)
+        self.touch: BrInputStats[HTTPClientT] | None = _touch and BrInputStats(data=_touch, http=http)
 
 
 class BrPlayerStats(ReconstructAble[dict[str, Any], HTTPClientT]):
@@ -325,10 +325,10 @@ class BrPlayerStats(ReconstructAble[dict[str, Any], HTTPClientT]):
         self.user: Account[HTTPClientT] = Account(data=_user, http=http)
 
         _battle_pass = data.get("battlePass")
-        self.battle_pass: Optional[BrBattlePass[HTTPClientT]] = _battle_pass and BrBattlePass(data=_battle_pass, http=http)
+        self.battle_pass: BrBattlePass[HTTPClientT] | None = _battle_pass and BrBattlePass(data=_battle_pass, http=http)
 
         _image = data.get("image")
-        self.image: Optional[Asset[HTTPClientT]] = _image and Asset(http=http, url=_image)
+        self.image: Asset[HTTPClientT] | None = _image and Asset(http=http, url=_image)
 
         _inputs = data.get("stats")
-        self.inputs: Optional[BrInputs[HTTPClientT]] = _inputs and BrInputs(data=_inputs, http=http)
+        self.inputs: BrInputs[HTTPClientT] | None = _inputs and BrInputs(data=_inputs, http=http)

--- a/fortnite_api/utils.py
+++ b/fortnite_api/utils.py
@@ -25,7 +25,8 @@ SOFTWARE.
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar
 
 K_co = TypeVar('K_co', bound='Hashable', covariant=True)
 V_co = TypeVar('V_co', covariant=True)
@@ -69,12 +70,12 @@ MISSING: Any = _MissingSentinel()
 
 if _has_orjson:
 
-    def to_json(string: Union[str, bytes]) -> dict[Any, Any]:
+    def to_json(string: str | bytes) -> dict[Any, Any]:
         return orjson.loads(string)  # type: ignore
 
 else:
 
-    def to_json(string: Union[str, bytes]) -> dict[Any, Any]:
+    def to_json(string: str | bytes) -> dict[Any, Any]:
         return json.loads(string)  # type: ignore
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ authors = [
 ]
 description = "A python wrapper for Fortnite-API.com"
 readme = "README.md"
-requires-python = ">=3.9.0"
+requires-python = ">=3.10.0"
 license = { file = "LICENSE" }
 keywords = [
     'fortnite',
@@ -44,11 +44,11 @@ classifiers = [
     'Intended Audience :: Developers',
     'Natural Language :: English',
     'Operating System :: OS Independent',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Internet',
     'Topic :: Software Development :: Libraries',
     'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
## Summary

This pull request drops support for Python 3.9 and adds Python 3.14. This includes:
- Tests are now run on Python 3.10
- 3.10 code changes are implemented (New Union syntax, Concatenate and TypeAlias now including in standard lib)
- Some type imports have been moved from typing to collections.abc (missed by a later change)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
